### PR TITLE
Continued development

### DIFF
--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -38,7 +38,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate test-environment
-        python -m pip install --ignore-installed --no-deps -q --no-cache-dir -e .
+        python -m pip install --ignore-installed --no-deps -q --no-cache-dir -e .[complete]
     - name: Run tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         pip install pip setuptools -U
         pip install wheel -U
-        pip install --ignore-installed --no-deps -q --no-cache-dir -e .[complete]
+        pip install --ignore-installed -q --no-cache-dir -e .[complete]
         pip list
     - name: test
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,11 +28,7 @@ jobs:
       run: |
         pip install pip setuptools -U
         pip install wheel -U
-        pip install pytest pytest-cov -U
-        pip install pyarrow
-        pip install dask[complete]
-        pip install --ignore-installed -q --no-cache-dir git+https://github.com/scikit-hep/awkward-1.0@main -v
-        pip install --ignore-installed --no-deps -q --no-cache-dir -e .
+        pip install --ignore-installed --no-deps -q --no-cache-dir -e .[complete]
         pip list
     - name: test
       run: |

--- a/.github/workflows/pypi-tests.yml
+++ b/.github/workflows/pypi-tests.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         pip install pip setuptools -U
         pip install wheel -U
-        pip install pytest -U
         pip install dask[complete]
         pip install --ignore-installed -q --no-cache-dir git+https://github.com/scikit-hep/awkward-1.0@main -v
         pip install --ignore-installed --no-deps -q --no-cache-dir -e .[complete]

--- a/.github/workflows/pypi-tests.yml
+++ b/.github/workflows/pypi-tests.yml
@@ -30,7 +30,7 @@ jobs:
         pip install wheel -U
         pip install dask[complete]
         pip install --ignore-installed -q --no-cache-dir git+https://github.com/scikit-hep/awkward-1.0@main -v
-        pip install --ignore-installed --no-deps -q --no-cache-dir -e .[complete]
+        pip install --ignore-installed -q --no-cache-dir -e .[complete]
         pip list
     - name: test
       run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ dask-awkward
 
 [![Tests](https://github.com/ContinuumIO/dask-awkward/actions/workflows/pypi-tests.yml/badge.svg)](https://github.com/ContinuumIO/dask-awkward/actions/workflows/pypi-tests.yml)
 [![Tests](https://github.com/ContinuumIO/dask-awkward/actions/workflows/conda-tests.yml/badge.svg)](https://github.com/ContinuumIO/dask-awkward/actions/workflows/conda-tests.yml)
+[![stability-alpha](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#alpha)
+
 
 **This software is very alpha!**
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ dask-awkward
 [Dask](https://dask.org/).
 
 [![Tests](https://github.com/ContinuumIO/dask-awkward/actions/workflows/pypi-tests.yml/badge.svg)](https://github.com/ContinuumIO/dask-awkward/actions/workflows/pypi-tests.yml)
+[![Tests](https://github.com/ContinuumIO/dask-awkward/actions/workflows/conda-tests.yml/badge.svg)](https://github.com/ContinuumIO/dask-awkward/actions/workflows/conda-tests.yml)
 
 **This software is very alpha!**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,13 @@ install_requires =
 io =
     pyarrow
 
+test =
+    pytest
+    pytest-cov
+
 complete =
     %(io)s
+    %(test)s
 
 docs =
     %(complete)s

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -5,7 +5,7 @@ import operator
 from functools import partial
 from math import ceil
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence
 
 import awkward._v2 as ak
 import numpy as np
@@ -977,4 +977,12 @@ def from_awkward(source: ak.Array, npartitions: int, name: str | None = None) ->
 
 
 def is_awkward_collection(obj: Any) -> bool:
-    return isinstance(obj, (Array, Record))
+    return isinstance(obj, (Array, Record, Scalar))
+
+
+def convert_collections_to_metas(objects: Sequence[Any]) -> tuple[Any]:
+    new_sequence = list(objects)
+    for i in range(len(new_sequence)):
+        if is_awkward_collection(new_sequence[i]):
+            new_sequence[i] = new_sequence[i].meta
+    return tuple(new_sequence)

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -980,9 +980,11 @@ def is_awkward_collection(obj: Any) -> bool:
     return isinstance(obj, (Array, Record, Scalar))
 
 
+def meta_or_identity(obj: Any) -> Any:
+    if is_awkward_collection(obj):
+        return obj.meta
+    return obj
+
+
 def convert_collections_to_metas(objects: Sequence[Any]) -> tuple[Any]:
-    new_sequence = list(objects)
-    for i in range(len(new_sequence)):
-        if is_awkward_collection(new_sequence[i]):
-            new_sequence[i] = new_sequence[i].meta
-    return tuple(new_sequence)
+    return tuple(map(meta_or_identity, objects))

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -398,7 +398,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         """
         return IndexCallable(self._partitions)
 
-    def _getitem_trivial_inner(self, where: Any) -> Array:
+    def _getitem_trivial_inner(self, where: tuple[Any, ...]) -> Array:
         token = tokenize(self, where)
         name = f"getitem-{token}"
         graphlayer = partitionwise_layer(
@@ -408,7 +408,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         meta = self.meta[where] if self.meta is not None else None
         return new_array_object(hlg, name, meta=meta, divisions=self.divisions)
 
-    def _getitem_single_int(self, where: int) -> Any:
+    def _getitem_single_int(self, where: tuple[Any, ...]) -> Any:
         # determine which partition to grab from (pidx) and which
         # index _inside_ of (relative to) that partition to then call
         # getitem with (rewriting key).
@@ -453,7 +453,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         else:
             return new_scalar_object(hlg, name, new_meta)
 
-    def _getitem_boolean_lazy_array(self, where: Any) -> Any:
+    def _getitem_boolean_lazy_array(self, where: tuple[Any, ...]) -> Any:
         outer_key = where[0]
         if outer_key.known_divisions and self.known_divisions:
             if outer_key.divisions != self.divisions:
@@ -476,11 +476,11 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
                 meta_where_has_non_none = True
             else:
                 meta_where.append(iw)
-        meta_where = tuple(meta_where)
+        meta_where = tuple(meta_where)  # type: ignore
 
         new_meta = None
         if meta_where_has_non_none:
-            new_meta = operator.getitem(self.meta, meta_where)
+            new_meta = operator.getitem(self.meta, meta_where)  # type: ignore
 
         return map_partitions(operator.getitem, self, *where, meta=new_meta)
 

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -986,5 +986,5 @@ def meta_or_identity(obj: Any) -> Any:
     return obj
 
 
-def convert_collections_to_metas(objects: Sequence[Any]) -> tuple[Any]:
+def convert_collections_to_metas(objects: Sequence[Any]) -> tuple[Any, ...]:
     return tuple(map(meta_or_identity, objects))

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -934,23 +934,27 @@ def ndim(array: Array) -> int | None:
     return None
 
 
-def fields(array: Array) -> list[str] | None:
+def fields(collection: Array | Record) -> list[str] | None:
     """Get the fields of a Array collection.
 
     Parameters
     ----------
-    array : dask_awkward.Array
-        The collection.
+    collection : dask_awkward.Array or dask_awkward.Record
+        Array or Record collection
 
     Returns
     -------
     list[str] or None
-        The fields of the array; if the array does not contain
-        metadata ``None`` is returned.
+        The fields of the collection; if the collection does not
+        contain metadata ``None`` is returned.
 
     """
-    if array.meta is not None:
-        return array.meta.fields
+    try:
+        m = collection.meta
+        if m is not None:
+            return m.fields
+    except AttributeError:
+        return None
     return None
 
 
@@ -978,6 +982,22 @@ def from_awkward(source: ak.Array, npartitions: int, name: str | None = None) ->
 
 def is_awkward_collection(obj: Any) -> bool:
     return isinstance(obj, (Array, Record, Scalar))
+
+
+def is_typetracer(obj: Any) -> bool:
+
+    if isinstance(obj, ak.Array):
+        if not obj.layout.nplike.known_shape and not obj.layout.nplike.known_data:
+            return True
+
+    if isinstance(obj, ak.Record):
+        if (
+            not obj.layout.array.nplike.known_shape
+            and not obj.layout.array.nplike.known_data
+        ):
+            return True
+
+    return False
 
 
 def meta_or_identity(obj: Any) -> Any:

--- a/src/dask_awkward/tests/test_core.py
+++ b/src/dask_awkward/tests/test_core.py
@@ -191,3 +191,34 @@ def test_record_collection() -> None:
 def test_scalar_collection() -> None:
     daa = _lazyrecords()
     assert type(daa["analysis"]["x1"][0][0]) is dakc.Scalar
+
+
+def test_is_typetracer() -> None:
+    daa = _lazyrecords()
+    assert not dakc.is_typetracer(daa)
+    assert not dakc.is_typetracer(daa[0])
+    assert not dakc.is_typetracer(daa["analysis"])
+    assert not dakc.is_typetracer(daa.compute())
+    assert dakc.is_typetracer(daa.meta)
+    assert dakc.is_typetracer(daa[0].meta)
+    assert dakc.is_typetracer(daa["analysis"].meta)
+    assert dakc.is_typetracer(daa["analysis"][0]["x1"][0].meta)
+
+
+def test_meta_or_identity() -> None:
+    daa = _lazyrecords()
+    assert dakc.is_typetracer(dakc.meta_or_identity(daa))
+    assert dakc.meta_or_identity(daa) is daa.meta
+    assert dakc.meta_or_identity(5) == 5
+
+
+def test_convert_collections_to_metas() -> None:
+    daa = _lazyrecords()
+    x1 = daa["analysis"]["x1"]
+    metad = dakc.convert_collections_to_metas([x1, 5, "ok"])
+    assert isinstance(metad, tuple)
+    for a, b in zip(metad, (x1.meta, 5, "ok")):
+        if dakc.is_typetracer(a):
+            assert a is b
+        else:
+            assert a == b

--- a/src/dask_awkward/tests/test_getitem.py
+++ b/src/dask_awkward/tests/test_getitem.py
@@ -31,10 +31,11 @@ def test_single_string(daa, caa) -> None:  # noqa: F811
 
 
 def test_layered_string(daa, caa) -> None:  # noqa: F811
-    assert_eq(daa["analysis", "x1"], caa["analysis", "x1"])
-    assert_eq(daa["analysis", "x1"], caa["analysis"]["x1"])
-    assert_eq(caa["analysis", "x1"], daa["analysis"]["x1"])
-    assert_eq(daa["analysis", ["x1", "t1"]], caa["analysis", ["x1", "t1"]])
+    with pytest.raises(NotImplementedError, match="support multi-object"):
+        assert_eq(daa["analysis", "x1"], caa["analysis", "x1"])
+        assert_eq(daa["analysis", "x1"], caa["analysis"]["x1"])
+        assert_eq(caa["analysis", "x1"], daa["analysis"]["x1"])
+        assert_eq(daa["analysis", ["x1", "t1"]], caa["analysis", ["x1", "t1"]])
 
 
 def test_list_with_ints_raise(daa) -> None:  # noqa: F811
@@ -47,7 +48,9 @@ def test_single_int(daa, caa) -> None:  # noqa: F811
     for i in range(total):
         assert_eq(daa["analysis"]["x1"][i], caa["analysis"]["x1"][i])
         assert_eq(daa["analysis"]["y2"][-i], caa["analysis"]["y2"][-i])
-        assert_eq(daa[0, "analysis", "x1"], caa[0, "analysis", "x1"])
+        with pytest.raises(NotImplementedError, match="support multi-object"):
+            assert_eq(daa["analysis", ["x1", "t1"]], caa["analysis", ["x1", "t1"]])
+            assert_eq(daa[0, "analysis", "x1"], caa[0, "analysis", "x1"])
     for i in range(total):
         caa[i].tolist() == daa[i].compute().tolist()
         caa["analysis"][i].tolist() == daa["analysis"][i].compute().tolist()
@@ -59,7 +62,8 @@ def test_single_ellipsis(daa, caa) -> None:  # noqa: F811
 
 def test_empty_slice(daa, caa) -> None:  # noqa: F811
     assert_eq(daa[:], caa[:])
-    assert_eq(daa[:, "analysis"], caa[:, "analysis"])
+    with pytest.raises(NotImplementedError, match="support multi-object"):
+        assert_eq(daa[:, "analysis"], caa[:, "analysis"])
 
 
 def test_record_getitem(daa, caa) -> None:  # noqa: F811

--- a/src/dask_awkward/tests/test_getitem.py
+++ b/src/dask_awkward/tests/test_getitem.py
@@ -30,6 +30,13 @@ def test_single_string(daa, caa) -> None:  # noqa: F811
     assert_eq(daa["analysis"], caa["analysis"])
 
 
+def test_layered_string(daa, caa) -> None:  # noqa: F811
+    assert_eq(daa["analysis", "x1"], caa["analysis", "x1"])
+    assert_eq(daa["analysis", "x1"], caa["analysis"]["x1"])
+    assert_eq(caa["analysis", "x1"], daa["analysis"]["x1"])
+    assert_eq(daa["analysis", ["x1", "t1"]], caa["analysis", ["x1", "t1"]])
+
+
 def test_list_with_ints_raise(daa) -> None:  # noqa: F811
     with pytest.raises(NotImplementedError, match="Lists containing integers"):
         assert daa[[1, 2]]
@@ -40,6 +47,7 @@ def test_single_int(daa, caa) -> None:  # noqa: F811
     for i in range(total):
         assert_eq(daa["analysis"]["x1"][i], caa["analysis"]["x1"][i])
         assert_eq(daa["analysis"]["y2"][-i], caa["analysis"]["y2"][-i])
+        assert_eq(daa[0, "analysis", "x1"], caa[0, "analysis", "x1"])
     for i in range(total):
         caa[i].tolist() == daa[i].compute().tolist()
         caa["analysis"][i].tolist() == daa["analysis"][i].compute().tolist()
@@ -51,6 +59,7 @@ def test_single_ellipsis(daa, caa) -> None:  # noqa: F811
 
 def test_empty_slice(daa, caa) -> None:  # noqa: F811
     assert_eq(daa[:], caa[:])
+    assert_eq(daa[:, "analysis"], caa[:, "analysis"])
 
 
 def test_record_getitem(daa, caa) -> None:  # noqa: F811


### PR DESCRIPTION
- **getitem**: Working on dedicated paths for single key vs tuple key inputs to `getitem` (see [discussion below](https://github.com/ContinuumIO/dask-awkward/pull/28#discussion_r789717041)).
  - Followup PR(s) to continue this
- **packaging**: improving setup.cfg
- **misc**: typetracer detection and utilities for grabbing typetracers from heterogenous mixed sequences of objects