### PR TITLE
struture and reductions; extending partitionwise with aggregation to scalar; tests; JSON I/O

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ build-backend = "setuptools.build_meta"
 write_to = "src/dask_awkward/_version.py"
 
 [tool.pytest.ini_options]
-addopts = "-v"
+testpaths = ["src/dask_awkward/tests"]
+addopts = ["-v", "-ra", "--showlocals", "--strict-markers", "--strict-config"]
 
 [tool.isort]
 profile = "black"

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -11,13 +11,13 @@ from typing import TYPE_CHECKING, Any, Callable, Hashable, Mapping, Sequence, Ty
 import awkward._v2 as ak
 import awkward._v2._typetracer as aktt
 import numpy as np
-from awkward._v2._connect.numpy import NDArrayOperatorsMixin
 from awkward._v2.highlevel import _dir_pattern
 from dask.base import DaskMethodsMixin, dont_optimize, is_dask_collection, tokenize
 from dask.blockwise import blockwise as upstream_blockwise
 from dask.highlevelgraph import HighLevelGraph
 from dask.threaded import get as threaded_get
 from dask.utils import IndexCallable, funcname, key_split
+from numpy.lib.mixins import NDArrayOperatorsMixin
 
 from .utils import is_empty_slice, normalize_single_outer_inner_index
 

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -827,8 +827,8 @@ def _get_typetracer(array: Array) -> ak.Array:
 
     Returns
     -------
-    Content
-        Awkward Content object representing the typetracer (metadata).
+    Array
+        Awkward high level array wrapping the typetracer (metadata).
 
     """
     if array.meta is not None:

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -1029,7 +1029,7 @@ def pw_reduction_with_agg_to_scalar(
     namefunc = f"{namefunc}-{token}"
     nameagg = f"{nameagg}-{token}"
     func = partial(func, **kwargs)
-    agg = partial(agg, **agg_kwargs) if agg_kwargs is not None else agg
+    agg = partial(agg, **agg_kwargs) if agg_kwargs is not None else agg  # type: ignore
     dsk = {(namefunc, i): (func, k) for i, k in enumerate(array.__dask_keys__())}
     dsk[nameagg] = (agg, list(dsk.keys()))  # type: ignore
     hlg = HighLevelGraph.from_collections(

--- a/src/dask_awkward/reducers.py
+++ b/src/dask_awkward/reducers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, Union
 
 import awkward._v2 as ak
+import numpy as np
 
 from .core import (
     DaskAwkwardNotImplemented,
@@ -132,7 +133,8 @@ def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records
         return pw_reduction_with_agg_to_scalar(
             trivial_result,
             ak.sum,
-            ak.sum,
+            agg=ak.sum,
+            dtype=np.int64,
         )
     elif axis == 0 or axis == -1 * array.ndim:
         raise DaskAwkwardNotImplemented(
@@ -164,7 +166,8 @@ def count_nonzero(
         return pw_reduction_with_agg_to_scalar(
             trivial_result,
             ak.sum,
-            ak.sum,
+            agg=ak.sum,
+            dtype=np.int64,
         )
     elif axis == 0 or axis == -1 * array.ndim:
         raise DaskAwkwardNotImplemented(
@@ -299,7 +302,7 @@ def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
             array, keepdims=False, mask_identity=False, flatten_records=False
         )
     elif axis is None:
-        return pw_reduction_with_agg_to_scalar(array, ak.sum, ak.sum)
+        return pw_reduction_with_agg_to_scalar(array, ak.sum, agg=ak.sum)
     elif axis == 0:
         raise DaskAwkwardNotImplemented(
             f"axis={axis} is not supported for this array yet."
@@ -335,7 +338,7 @@ def _min_or_max(
     if axis == 1:
         return tf(array, axis=axis, **kwargs)
     elif axis is None:
-        return pw_reduction_with_agg_to_scalar(array, f, f, **kwargs)
+        return pw_reduction_with_agg_to_scalar(array, f, agg=f, **kwargs)
     elif array.ndim is not None and (axis == 0 or axis == -1 * array.ndim):
         raise DaskAwkwardNotImplemented(
             f"axis={axis} is not supported for this array yet."

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 import awkward._v2 as ak
+import numpy as np
 
 from dask_awkward.core import (
     DaskAwkwardNotImplemented,
     TrivialPartitionwiseOp,
+    map_partitions,
     new_known_scalar,
+    pw_reduction_with_agg_to_scalar,
 )
 
 __all__ = (
@@ -133,7 +136,13 @@ def firsts(array, axis=1, highlevel=True, behavior=None):
 
 
 def flatten(array, axis=1, highlevel=True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+    return map_partitions(
+        ak.flatten,
+        array,
+        axis=axis,
+        highlevel=highlevel,
+        behavior=behavior,
+    )
 
 
 def from_regular(array, axis=1, highlevel=True, behavior=None):
@@ -170,17 +179,24 @@ def nan_to_num(
 
 def num(array: Any, axis: int | None = 1, highlevel: bool = True, behavior=None) -> Any:
     if axis == 1:
-        return _num_trivial(
-            array,
-            axis=axis,
-            highlevel=True,
-            behavior=behavior,
+        return map_partitions(
+            ak.num, array, axis=axis, highlevel=highlevel, behavior=behavior
         )
     if axis == 0:
         if array.known_divisions:
             res = array.divisions[-1]  # noqa: F841
             return new_known_scalar(array.divisions[-1], dtype=int)
-
+        else:
+            return pw_reduction_with_agg_to_scalar(
+                array,
+                ak.num,
+                axis=0,
+                dtype=np.int64,
+                agg=ak.sum,
+                agg_kwargs={"axis": None},
+                highlevel=highlevel,
+                behavior=behavior,
+            )
     raise DaskAwkwardNotImplemented("TODO")
 
 

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -5,7 +5,7 @@ from typing import Any
 import awkward._v2 as ak
 import numpy as np
 
-from dask_awkward.core import (
+from .core import (
     DaskAwkwardNotImplemented,
     TrivialPartitionwiseOp,
     map_partitions,

--- a/src/dask_awkward/tests/conftest.py
+++ b/src/dask_awkward/tests/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+
+from dask_awkward.testutils import (
+    MANY_RECORDS,
+    SINGLE_RECORD,
+    load_records_eager,
+    load_records_lazy,
+)
+
+
+@pytest.fixture(scope="session")
+def line_delim_records_file(tmpdir_factory):
+    """Fixture providing a file name pointing to line deliminted JSON records."""
+    fn = tmpdir_factory.mktemp("data").join("records.json")
+    with open(fn, "w") as f:
+        f.write(MANY_RECORDS)
+    return str(fn)
+
+
+@pytest.fixture(scope="session")
+def single_record_file(tmpdir_factory):
+    """Fixture providing file name pointing to a single JSON record."""
+    fn = tmpdir_factory.mktemp("data").join("single-record.json")
+    with open(fn, "w") as f:
+        f.write(SINGLE_RECORD)
+    return str(fn)
+
+
+@pytest.fixture(scope="session")
+def daa(tmpdir_factory):
+    """Fixture providing a Dask Awkward Array collection."""
+    fn = tmpdir_factory.mktemp("data").join("records.json")
+    with open(fn, "w") as f:
+        f.write(MANY_RECORDS)
+    return load_records_lazy(fn)
+
+
+@pytest.fixture(scope="session")
+def caa(tmpdir_factory):
+    """Fixture providing a concrete Awkward Array."""
+    fn = tmpdir_factory.mktemp("data").join("records.json")
+    with open(fn, "w") as f:
+        f.write(MANY_RECORDS)
+    return load_records_eager(fn)

--- a/src/dask_awkward/tests/test_core.py
+++ b/src/dask_awkward/tests/test_core.py
@@ -318,13 +318,13 @@ def test_scalar_pickle() -> None:
 
     s = 2
     c1 = dakc.new_known_scalar(s)
-    s = pickle.dumps(c1)
-    c2 = pickle.loads(s)
+    s_dumped = pickle.dumps(c1)
+    c2 = pickle.loads(s_dumped)
     assert_eq(c1, c2)
     daa = _lazyjsonrecords()
     s1 = dak.sum(daa["analysis"]["x1"], axis=None)
-    s = pickle.dumps(s1)
-    s2 = pickle.loads(s)
+    s_dumped = pickle.dumps(s1)
+    s2 = pickle.loads(s_dumped)
     assert_eq(s1, s2)
 
     assert s1.known_value is None

--- a/src/dask_awkward/tests/test_core.py
+++ b/src/dask_awkward/tests/test_core.py
@@ -6,12 +6,11 @@ import pytest
 
 import dask_awkward as dak
 import dask_awkward.core as dakc
-from dask_awkward.testutils import (  # noqa: F401
+from dask_awkward.testutils import (
     _lazyjsonrecords,
     _lazyrecord,
     _lazyrecords,
     assert_eq,
-    line_delim_records_file,
     load_records_eager,
     load_records_lazy,
 )
@@ -26,13 +25,13 @@ def test_clear_divisions() -> None:
     assert_eq(daa, daa)
 
 
-def test_dunder_str(line_delim_records_file) -> None:  # noqa: F811
+def test_dunder_str(line_delim_records_file) -> None:
     aa = load_records_eager(line_delim_records_file)
     daa = dak.from_awkward(aa, npartitions=6)
     assert str(daa) == "dask.awkward<from-awkward, npartitions=5>"
 
 
-def test_calculate_known_divisions(line_delim_records_file) -> None:  # noqa: F811
+def test_calculate_known_divisions(line_delim_records_file) -> None:
     daa = dak.from_json([line_delim_records_file] * 3)
     target = (0, 20, 40, 60)
     assert dakc.calculate_known_divisions(daa) == target
@@ -45,7 +44,7 @@ def test_calculate_known_divisions(line_delim_records_file) -> None:  # noqa: F8
     assert dakc.calculate_known_divisions(daa) == target
 
 
-def test_fields(line_delim_records_file) -> None:  # noqa: F811
+def test_fields(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file, blocksize=340)
     # records fields same as array of records fields
     assert daa[0].analysis.fields == daa.analysis.fields
@@ -57,7 +56,7 @@ def test_fields(line_delim_records_file) -> None:  # noqa: F811
     assert dak.fields(daa) is None
 
 
-def test_form(line_delim_records_file) -> None:  # noqa: F811
+def test_form(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file)
     assert daa.form
     daa.meta = None
@@ -65,7 +64,7 @@ def test_form(line_delim_records_file) -> None:  # noqa: F811
 
 
 @pytest.mark.xfail
-def test_form_equality(line_delim_records_file) -> None:  # noqa: F811
+def test_form_equality(line_delim_records_file) -> None:
     # NOTE: forms come from meta which currently depends on partitioning
     daa = dak.from_json(line_delim_records_file)
     assert daa.form == daa.compute().layout.form
@@ -73,7 +72,7 @@ def test_form_equality(line_delim_records_file) -> None:  # noqa: F811
     assert daa.form == daa.compute().layout.form
 
 
-def test_from_awkward(line_delim_records_file) -> None:  # noqa: F811
+def test_from_awkward(line_delim_records_file) -> None:
     aa = load_records_eager(line_delim_records_file)
     daa = dak.from_awkward(aa, npartitions=4)
     assert_eq(aa, daa)
@@ -85,19 +84,19 @@ def test_get_typetracer() -> None:
     assert dakc._get_typetracer(daa) is daa.meta
 
 
-def test_len(line_delim_records_file) -> None:  # noqa: F811
+def test_len(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file)
     assert len(daa) == 20
 
 
-def test_meta_and_typetracer_exist(line_delim_records_file) -> None:  # noqa: F811
+def test_meta_and_typetracer_exist(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file, blocksize=700)
     assert daa.meta is not None
     assert daa["analysis"]["x1"].meta is not None
     assert daa.typetracer is daa.meta
 
 
-def test_meta_raise(line_delim_records_file) -> None:  # noqa: F811
+def test_meta_raise(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file)
     with pytest.raises(
         TypeError, match="meta must be an instance of an Awkward Array."
@@ -105,14 +104,14 @@ def test_meta_raise(line_delim_records_file) -> None:  # noqa: F811
         daa.meta = "hello"
 
 
-def test_ndim(line_delim_records_file) -> None:  # noqa
+def test_ndim(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file, blocksize=700)
     assert daa.ndim == daa.compute().ndim
     daa.meta = None
     assert daa.ndim is None
 
 
-def test_new_array_object_raises(line_delim_records_file) -> None:  # noqa: F811
+def test_new_array_object_raises(line_delim_records_file) -> None:
     daa = dak.from_json(line_delim_records_file)
     name = daa.name
     hlg = daa.dask
@@ -282,7 +281,7 @@ def test_typetracer_function() -> None:
     assert tta.layout.form == aa.layout.form
 
 
-def test_single_partition(line_delim_records_file) -> None:  # noqa: F811
+def test_single_partition(line_delim_records_file) -> None:
     daa = load_records_lazy(line_delim_records_file, by_file=True, n_times=1)
     caa = load_records_eager(line_delim_records_file)
     assert daa.npartitions == 1

--- a/src/dask_awkward/tests/test_getitem.py
+++ b/src/dask_awkward/tests/test_getitem.py
@@ -6,15 +6,10 @@ import pytest
 
 import dask_awkward as dak
 import dask_awkward.core as dakc
-from dask_awkward.testutils import (  # noqa: F401
-    assert_eq,
-    caa,
-    daa,
-    line_delim_records_file,
-)
+from dask_awkward.testutils import assert_eq
 
 
-def test_getattr_raise(daa) -> None:  # noqa: F811
+def test_getattr_raise(daa) -> None:
     dar = daa[0]
     assert type(dar) is dakc.Record
     with pytest.raises(AttributeError, match="not in fields"):
@@ -23,18 +18,18 @@ def test_getattr_raise(daa) -> None:  # noqa: F811
         assert dar.x3
 
 
-def test_multi_string(daa, caa) -> None:  # noqa: F811
+def test_multi_string(daa, caa) -> None:
     assert_eq(
         daa["analysis"][["x1", "y2"]],
         caa["analysis"][["x1", "y2"]],
     )
 
 
-def test_single_string(daa, caa) -> None:  # noqa: F811
+def test_single_string(daa, caa) -> None:
     assert_eq(daa["analysis"], caa["analysis"])
 
 
-def test_layered_string(daa, caa) -> None:  # noqa: F811
+def test_layered_string(daa, caa) -> None:
     assert_eq(daa["analysis", "x1"], caa["analysis", "x1"])
     assert_eq(daa["analysis", "x1"], caa["analysis"]["x1"])
     assert_eq(caa["analysis", "x1"], daa["analysis"]["x1"])
@@ -42,12 +37,12 @@ def test_layered_string(daa, caa) -> None:  # noqa: F811
     assert_eq(daa["analysis", ["x1", "t1"]], caa["analysis", ["x1", "t1"]])
 
 
-def test_list_with_ints_raise(daa) -> None:  # noqa: F811
+def test_list_with_ints_raise(daa) -> None:
     with pytest.raises(RuntimeError, match="Lists containing integers"):
         assert daa[[1, 2]]
 
 
-def test_single_int(daa, caa) -> None:  # noqa: F811
+def test_single_int(daa, caa) -> None:
     total = len(daa)
     for i in range(total):
         assert_eq(daa["analysis"]["x1"][i], caa["analysis"]["x1"][i])
@@ -58,16 +53,16 @@ def test_single_int(daa, caa) -> None:  # noqa: F811
         caa["analysis"][i].tolist() == daa["analysis"][i].compute().tolist()
 
 
-def test_single_ellipsis(daa, caa) -> None:  # noqa: F811
+def test_single_ellipsis(daa, caa) -> None:
     assert_eq(daa[...], caa[...])
 
 
-def test_empty_slice(daa, caa) -> None:  # noqa: F811
+def test_empty_slice(daa, caa) -> None:
     assert_eq(daa[:], caa[:])
     assert_eq(daa[:, "analysis"], caa[:, "analysis"])
 
 
-def test_record_getitem(daa, caa) -> None:  # noqa: F811
+def test_record_getitem(daa, caa) -> None:
     assert daa[0].compute().to_list() == caa[0].to_list()
     assert daa["analysis"]["x1"][0][0].compute() == caa["analysis"]["x1"][0][0]
     assert daa[0]["analysis"].compute().to_list() == caa[0]["analysis"].to_list()
@@ -77,7 +72,7 @@ def test_record_getitem(daa, caa) -> None:  # noqa: F811
 
 
 @pytest.mark.parametrize("op", [operator.gt, operator.ge, operator.le, operator.lt])
-def test_boolean_array(line_delim_records_file, op) -> None:  # noqa: F811
+def test_boolean_array(line_delim_records_file, op) -> None:
     daa = dak.from_json([line_delim_records_file] * 3)  # noqa
     caa = daa.compute()  # noqa
     dx1 = daa.analysis.x1

--- a/src/dask_awkward/tests/test_reducers.py
+++ b/src/dask_awkward/tests/test_reducers.py
@@ -4,14 +4,14 @@ import awkward._v2 as ak
 import pytest
 
 import dask_awkward as dak
-from dask_awkward.testutils import assert_eq, caa, daa  # noqa: F401
+from dask_awkward.testutils import assert_eq
 
 
 @pytest.mark.parametrize("axis", [1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 @pytest.mark.parametrize("testval", [-1, 3, 100])
-def test_all(daa, caa, axis, keepdims, mask_identity, testval) -> None:  # noqa: F811
+def test_all(daa, caa, axis, keepdims, mask_identity, testval) -> None:
     x1d = daa.analysis.x1
     x1c = caa.analysis.x1
     maskd = x1d > testval
@@ -25,7 +25,7 @@ def test_all(daa, caa, axis, keepdims, mask_identity, testval) -> None:  # noqa:
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 @pytest.mark.parametrize("testval", [-1, 3, 100])
-def test_any(daa, caa, axis, keepdims, mask_identity, testval) -> None:  # noqa: F811
+def test_any(daa, caa, axis, keepdims, mask_identity, testval) -> None:
     x1d = daa.analysis.x1
     x1c = caa.analysis.x1
     maskd = x1d > testval
@@ -45,7 +45,7 @@ def test_argmax(daa, caa, axis) -> None:  # noqa: F811
 
 
 @pytest.mark.parametrize("axis", [1])
-def test_argmin(daa, caa, axis) -> None:  # noqa: F811
+def test_argmin(daa, caa, axis) -> None:
     x1d = daa.analysis.x1
     x1c = caa.analysis.x1
     dr = dak.argmax(x1d, axis=axis)
@@ -54,14 +54,14 @@ def test_argmin(daa, caa, axis) -> None:  # noqa: F811
 
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
-def test_count(daa, caa, axis) -> None:  # noqa: F811
+def test_count(daa, caa, axis) -> None:
     ar = ak.count(caa["analysis"]["x1"], axis=axis)
     dr = dak.count(daa["analysis"]["x1"], axis=axis)
     assert_eq(ar, dr)
 
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
-def test_count_nonzero(daa, caa, axis) -> None:  # noqa: F811
+def test_count_nonzero(daa, caa, axis) -> None:
     ar = ak.count_nonzero(caa["analysis", "x1"], axis=axis)
     dr = dak.count_nonzero(daa["analysis"]["x1"], axis=axis)
     assert_eq(ar, dr)
@@ -69,7 +69,7 @@ def test_count_nonzero(daa, caa, axis) -> None:  # noqa: F811
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
 @pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_max(daa, caa, axis, attr) -> None:  # noqa: F811
+def test_max(daa, caa, axis, attr) -> None:
     ar = ak.max(caa.analysis[attr], axis=axis)
     dr = dak.max(daa.analysis[attr], axis=axis)
     assert_eq(ar, dr)
@@ -77,7 +77,7 @@ def test_max(daa, caa, axis, attr) -> None:  # noqa: F811
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
 @pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_min(daa, caa, axis, attr) -> None:  # noqa: F811
+def test_min(daa, caa, axis, attr) -> None:
     ar = ak.min(caa.analysis[attr], axis=axis)
     dr = dak.min(daa["analysis", attr], axis=axis)
     assert_eq(ar, dr)
@@ -85,7 +85,7 @@ def test_min(daa, caa, axis, attr) -> None:  # noqa: F811
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
 @pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_sum(daa, caa, axis, attr) -> None:  # noqa: F811
+def test_sum(daa, caa, axis, attr) -> None:
     ar = ak.sum(caa.analysis[attr], axis=axis)
     dr = dak.sum(daa.analysis[attr], axis=axis)
     assert_eq(ar, dr)

--- a/src/dask_awkward/tests/test_reducers.py
+++ b/src/dask_awkward/tests/test_reducers.py
@@ -35,28 +35,22 @@ def test_any(daa, caa, axis, keepdims, mask_identity, testval) -> None:  # noqa:
     assert_eq(ar, dr)
 
 
-@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
-@pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_min(daa, caa, axis, attr) -> None:  # noqa: F811
-    ar = ak.min(caa.analysis[attr], axis=axis)
-    dr = dak.min(daa["analysis", attr], axis=axis)
-    assert_eq(ar, dr)
+@pytest.mark.parametrize("axis", [1])
+def test_argmax(daa, caa, axis) -> None:  # noqa: F811
+    x1d = daa.analysis.x1
+    x1c = caa.analysis.x1
+    dr = dak.argmax(x1d, axis=axis)
+    ar = ak.argmax(x1c, axis=axis)
+    assert_eq(dr, ar)
 
 
-@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
-@pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_max(daa, caa, axis, attr) -> None:  # noqa: F811
-    ar = ak.max(caa.analysis[attr], axis=axis)
-    dr = dak.max(daa.analysis[attr], axis=axis)
-    assert_eq(ar, dr)
-
-
-@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
-@pytest.mark.parametrize("attr", ["x1", "z2"])
-def test_sum(daa, caa, axis, attr) -> None:  # noqa: F811
-    ar = ak.sum(caa.analysis[attr], axis=axis)
-    dr = dak.sum(daa.analysis[attr], axis=axis)
-    assert_eq(ar, dr)
+@pytest.mark.parametrize("axis", [1])
+def test_argmin(daa, caa, axis) -> None:  # noqa: F811
+    x1d = daa.analysis.x1
+    x1c = caa.analysis.x1
+    dr = dak.argmax(x1d, axis=axis)
+    ar = ak.argmax(x1c, axis=axis)
+    assert_eq(dr, ar)
 
 
 @pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
@@ -70,4 +64,28 @@ def test_count(daa, caa, axis) -> None:  # noqa: F811
 def test_count_nonzero(daa, caa, axis) -> None:  # noqa: F811
     ar = ak.count_nonzero(caa["analysis", "x1"], axis=axis)
     dr = dak.count_nonzero(daa["analysis"]["x1"], axis=axis)
+    assert_eq(ar, dr)
+
+
+@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("attr", ["x1", "z2"])
+def test_max(daa, caa, axis, attr) -> None:  # noqa: F811
+    ar = ak.max(caa.analysis[attr], axis=axis)
+    dr = dak.max(daa.analysis[attr], axis=axis)
+    assert_eq(ar, dr)
+
+
+@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("attr", ["x1", "z2"])
+def test_min(daa, caa, axis, attr) -> None:  # noqa: F811
+    ar = ak.min(caa.analysis[attr], axis=axis)
+    dr = dak.min(daa["analysis", attr], axis=axis)
+    assert_eq(ar, dr)
+
+
+@pytest.mark.parametrize("axis", [None, 1, pytest.param(-1, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("attr", ["x1", "z2"])
+def test_sum(daa, caa, axis, attr) -> None:  # noqa: F811
+    ar = ak.sum(caa.analysis[attr], axis=axis)
+    dr = dak.sum(daa.analysis[attr], axis=axis)
     assert_eq(ar, dr)

--- a/src/dask_awkward/tests/test_structure.py
+++ b/src/dask_awkward/tests/test_structure.py
@@ -6,10 +6,19 @@ import pytest
 import dask_awkward as dak
 from dask_awkward.testutils import (  # noqa: F401
     assert_eq,
+    caa,
+    daa,
     line_delim_records_file,
     load_records_eager,
     load_records_lazy,
 )
+
+
+@pytest.mark.parametrize("axis", [None, 0, 1])
+def test_flatten(caa, daa, axis) -> None:  # noqa: F811
+    cr = ak.flatten(caa.analysis.x2, axis=axis)
+    dr = dak.flatten(daa.analysis.x2, axis=axis)
+    assert_eq(cr, dr)
 
 
 @pytest.mark.parametrize(
@@ -21,16 +30,17 @@ from dask_awkward.testutils import (  # noqa: F401
     ],
 )
 def test_num(line_delim_records_file, axis) -> None:  # noqa: F811
-    daa = load_records_lazy(line_delim_records_file)["analysis"]
-    caa = load_records_eager(line_delim_records_file)["analysis"]
+    da = load_records_lazy(line_delim_records_file)["analysis"]
+    ca = load_records_eager(line_delim_records_file)["analysis"]
 
     # TODO: also test before this forced computation.
     if axis == 0:
-        daa.eager_compute_divisions()
+        assert_eq(dak.num(da.x1, axis=axis), ak.num(ca.x1, axis=axis))
+        da.eager_compute_divisions()
 
-    assert_eq(dak.num(daa.x1, axis=axis), ak.num(caa.x1, axis=axis))
+    assert_eq(dak.num(da.x1, axis=axis), ak.num(ca.x1, axis=axis))
 
     if axis == 1:
-        c1 = dak.num(daa.x1, axis=axis) > 2
-        c2 = ak.num(caa.x1, axis=axis) > 2
-        assert_eq(daa[c1], caa[c2])
+        c1 = dak.num(da.x1, axis=axis) > 2
+        c2 = ak.num(ca.x1, axis=axis) > 2
+        assert_eq(da[c1], ca[c2])

--- a/src/dask_awkward/tests/test_structure.py
+++ b/src/dask_awkward/tests/test_structure.py
@@ -4,18 +4,11 @@ import awkward._v2 as ak
 import pytest
 
 import dask_awkward as dak
-from dask_awkward.testutils import (  # noqa: F401
-    assert_eq,
-    caa,
-    daa,
-    line_delim_records_file,
-    load_records_eager,
-    load_records_lazy,
-)
+from dask_awkward.testutils import assert_eq, load_records_eager, load_records_lazy
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1])
-def test_flatten(caa, daa, axis) -> None:  # noqa: F811
+def test_flatten(caa, daa, axis) -> None:
     cr = ak.flatten(caa.analysis.x2, axis=axis)
     dr = dak.flatten(daa.analysis.x2, axis=axis)
     assert_eq(cr, dr)
@@ -29,11 +22,10 @@ def test_flatten(caa, daa, axis) -> None:  # noqa: F811
         1,
     ],
 )
-def test_num(line_delim_records_file, axis) -> None:  # noqa: F811
+def test_num(line_delim_records_file, axis) -> None:
     da = load_records_lazy(line_delim_records_file)["analysis"]
     ca = load_records_eager(line_delim_records_file)["analysis"]
 
-    # TODO: also test before this forced computation.
     if axis == 0:
         assert_eq(dak.num(da.x1, axis=axis), ak.num(ca.x1, axis=axis))
         da.eager_compute_divisions()

--- a/src/dask_awkward/tests/test_ufunc.py
+++ b/src/dask_awkward/tests/test_ufunc.py
@@ -3,15 +3,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from dask_awkward.testutils import (  # noqa: F401
-    assert_eq,
-    line_delim_records_file,
-    load_records_eager,
-    load_records_lazy,
-)
+from dask_awkward.testutils import assert_eq, load_records_eager, load_records_lazy
 
 
-def test_ufunc_add(line_delim_records_file) -> None:  # noqa: F811
+def test_ufunc_add(line_delim_records_file) -> None:
     daa = load_records_lazy(line_delim_records_file).analysis.x1
     caa = load_records_eager(line_delim_records_file).analysis.x1
     a1 = daa + 2
@@ -19,7 +14,7 @@ def test_ufunc_add(line_delim_records_file) -> None:  # noqa: F811
     assert_eq(a1, a2)
 
 
-def test_ufunc_sin(line_delim_records_file) -> None:  # noqa: F811
+def test_ufunc_sin(line_delim_records_file) -> None:
     daa = load_records_lazy(line_delim_records_file).analysis.x1
     caa = load_records_eager(line_delim_records_file).analysis.x1
     a1 = np.sin(daa)
@@ -28,7 +23,7 @@ def test_ufunc_sin(line_delim_records_file) -> None:  # noqa: F811
 
 
 @pytest.mark.parametrize("f", [np.add.accumulate, np.add.reduce])
-def test_ufunc_method_raise(line_delim_records_file, f) -> None:  # noqa: F811
+def test_ufunc_method_raise(line_delim_records_file, f) -> None:
     daa = load_records_lazy(line_delim_records_file).analysis.x1
     with pytest.raises(RuntimeError, match="Array ufunc supports only method"):
         f(daa, daa)

--- a/src/dask_awkward/testutils.py
+++ b/src/dask_awkward/testutils.py
@@ -13,14 +13,6 @@ try:
 except ImportError:
     import json  # type: ignore
 
-try:
-    import pytest
-except ImportError:
-    raise ImportError(
-        "This module provides utilities for testing with "
-        "dask-awkward; you'll need to install pytest."
-    )
-
 from .core import Array, Record, from_awkward, typetracer_array
 from .io import from_json
 
@@ -138,42 +130,6 @@ MANY_RECORDS = \
 
 SINGLE_RECORD = """{"a":[1,2,3]}"""
 # fmt: on
-
-
-@pytest.fixture(scope="session")
-def line_delim_records_file(tmpdir_factory):
-    """Fixture providing a file name pointing to line deliminted JSON records."""
-    fn = tmpdir_factory.mktemp("data").join("records.json")
-    with open(fn, "w") as f:
-        f.write(MANY_RECORDS)
-    return str(fn)
-
-
-@pytest.fixture(scope="session")
-def single_record_file(tmpdir_factory):
-    """Fixture providing file name pointing to a single JSON record."""
-    fn = tmpdir_factory.mktemp("data").join("single-record.json")
-    with open(fn, "w") as f:
-        f.write(SINGLE_RECORD)
-    return str(fn)
-
-
-@pytest.fixture(scope="session")
-def daa(tmpdir_factory):
-    """Fixture providing a Dask Awkward Array collection."""
-    fn = tmpdir_factory.mktemp("data").join("records.json")
-    with open(fn, "w") as f:
-        f.write(MANY_RECORDS)
-    return load_records_lazy(fn)
-
-
-@pytest.fixture(scope="session")
-def caa(tmpdir_factory):
-    """Fixture providing a concrete Awkward Array."""
-    fn = tmpdir_factory.mktemp("data").join("records.json")
-    with open(fn, "w") as f:
-        f.write(MANY_RECORDS)
-    return load_records_eager(fn)
 
 
 def records_from_temp_file(n_times: int = 1) -> ak.Array:

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -46,6 +46,29 @@ def normalize_single_outer_inner_index(
 
 
 def is_empty_slice(s: Any) -> bool:
+    """Check if a slice is empty.
+
+    Parameters
+    ----------
+    s : Any
+        Slice of interest
+
+    Returns
+    -------
+    bool
+        True if the slice is empty
+
+    Examples
+    --------
+    >>> from dask_awkward.utils import is_empty_slice
+    >>> is_empty_slice(slice(1, 5, None))
+    False
+    >>> is_empty_slice(slice(None, None, 2))
+    False
+    >>> is_empty_slice(slice(None, None, None))
+    True
+
+    """
     if not isinstance(s, slice):
         return False
     if s.start is not None:

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -19,9 +19,9 @@ def normalize_single_outer_inner_index(
 
     Returns
     -------
-    int
+    partition_index : int
         Which partition in the collection.
-    int
+    new_index : int
         Which inner index in the determined partition.
 
     Examples
@@ -55,7 +55,7 @@ def is_empty_slice(s: Any) -> bool:
 
     Returns
     -------
-    bool
+    result : bool
         True if the slice is empty
 
     Examples


### PR DESCRIPTION
- more work on structure & reducer functions
  - improvements to partitionwise with aggregation to scalar
-  improving test infra
   - proper organization (use `conftest.py` for shared fixtures)
- improvements to JSON I/O
  - leverage `fsspec`
  - use wrapper callables
  - infer compression