### PR TITLE
use dask.config; rename meta property to _meta, also privatize typetracer

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -1,9 +1,11 @@
+from . import config  # isort:skip; load awkward config
+
 from ._version import version
 from .core import Array, Record, Scalar
 from .core import _type as type
 from .core import from_awkward, map_partitions
 from .describe import fields
-from .io import from_json
+from .io import *
 from .reducers import *
 from .structure import *
 

--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -1,0 +1,2 @@
+awkward:
+  compute-unknown-meta: True

--- a/src/dask_awkward/config.py
+++ b/src/dask_awkward/config.py
@@ -1,0 +1,12 @@
+import os
+
+import dask.config
+import yaml
+
+config = dask.config.config
+
+fn = os.path.join(os.path.dirname(__file__), "awkward.yaml")
+with open(fn) as f:
+    defaults = yaml.safe_load(f)
+
+dask.config.update_defaults(defaults)

--- a/src/dask_awkward/tests/test_describe.py
+++ b/src/dask_awkward/tests/test_describe.py
@@ -9,6 +9,6 @@ def test_fields(line_delim_records_file) -> None:
     assert dak.fields(daa[0].analysis) == dak.fields(daa.analysis)
     # computed is same as collection
     assert dak.fields(daa) == ak.fields(daa.compute())
-    daa.meta = None
+    daa._meta = None
     # removed meta gives None fields
     assert dak.fields(daa) is None


### PR DESCRIPTION
- Adding an `awkward` entry to `dask.config`
  - The only option so far is `compute-unknown-meta` which by default is set to `True`. If the option is `False`, when a new collection is created with unknown meta we will leave it as `None`. (The default behavior is to use the first partition to compute metadata (typetracer array) eagerly.
- rename the `meta` property to `_meta` (consistent with core Dask collections)
  - also "privatize" the typetracer property as `_typetracer`
- Use Dask's `dask.config.set` context manager for setting `awkward.compute-unknown-meta` to `False` instead of the `ignore_meta` kwarg described in #37 