### PR TITLE
New `output_divisions` argument for `map_partitions`

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -3,6 +3,7 @@ from dask_awkward import config  # isort:skip; load awkward config
 from dask_awkward._version import version
 from dask_awkward.core import Array, Record, Scalar
 from dask_awkward.core import _type as type
+from dask_awkward.core import map_partitions
 from dask_awkward.describe import fields
 from dask_awkward.io import (
     from_awkward,

--- a/src/dask_awkward/reducers.py
+++ b/src/dask_awkward/reducers.py
@@ -41,6 +41,7 @@ def all(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
         return map_partitions(
             ak.all,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -55,6 +56,7 @@ def any(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
         return map_partitions(
             ak.any,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -69,6 +71,7 @@ def argmax(array, axis=None, keepdims=False, mask_identity=True, flatten_records
         return map_partitions(
             ak.argmax,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -83,6 +86,7 @@ def argmin(array, axis=None, keepdims=False, mask_identity=True, flatten_records
         return map_partitions(
             ak.argmin,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -112,6 +116,7 @@ def count(array, axis=None, keepdims=False, mask_identity=False, flatten_records
         return map_partitions(
             ak.count,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -148,6 +153,7 @@ def count_nonzero(
         return map_partitions(
             ak.count_nonzero,
             array,
+            output_divisions=1,
             axis=1,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -219,6 +225,7 @@ def max(
         return map_partitions(
             ak.max,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             initial=initial,
@@ -250,6 +257,7 @@ def mean(
         return map_partitions(
             ak.mean,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,
@@ -271,6 +279,7 @@ def min(
         return map_partitions(
             ak.min,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             initial=initial,
@@ -334,6 +343,7 @@ def std(
         return map_partitions(
             ak.std,
             x,
+            output_divisions=1,
             weight=weight,
             ddof=ddof,
             axis=axis,
@@ -352,6 +362,7 @@ def sum(array, axis=None, keepdims=False, mask_identity=False, flatten_records=F
         return map_partitions(
             ak.sum,
             array,
+            output_divisions=1,
             axis=axis,
             keepdims=keepdims,
             mask_identity=mask_identity,

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -222,6 +222,7 @@ def nan_to_num(
     return map_partitions(
         ak.nan_to_num,
         array,
+        output_partitions=1,
         copy=copy,
         nan=nan,
         posinf=posinf,

--- a/src/dask_awkward/tests/test_core.py
+++ b/src/dask_awkward/tests/test_core.py
@@ -393,3 +393,13 @@ def test_scalar_persist(daa: dakc.Array) -> None:
     coll = daa["analysis"]["x1"][0][0]
     coll2 = coll.persist()
     assert_eq(coll, coll2)
+
+
+def test_output_divisions(daa: dakc.Array) -> None:
+    assert dak.max(daa.analysis.x1, axis=1).divisions == daa.divisions
+    assert dak.num(daa.analysis.x1, axis=1).divisions == (None,) * (daa.npartitions + 1)
+
+
+def test_record_npartitions(daa: dakc.Array) -> None:
+    analysis0 = daa[0]
+    assert analysis0.npartitions == 1

--- a/src/dask_awkward/tests/test_core.py
+++ b/src/dask_awkward/tests/test_core.py
@@ -398,6 +398,8 @@ def test_scalar_persist(daa: dakc.Array) -> None:
 def test_output_divisions(daa: dakc.Array) -> None:
     assert dak.max(daa.analysis.x1, axis=1).divisions == daa.divisions
     assert dak.num(daa.analysis.x1, axis=1).divisions == (None,) * (daa.npartitions + 1)
+    assert daa["analysis"][["x1", "x2"]].divisions == daa.divisions
+    assert daa["analysis"].divisions == daa.divisions
 
 
 def test_record_npartitions(daa: dakc.Array) -> None:


### PR DESCRIPTION
`map_partitions` has been given a new argument: `output_divisions` for defining the behavior of the divisions of the output.

- `None` (the default) will cause divisions to be wiped clean. `npartitions` will remain the same but we will "forget" the divisions, as we have no way of knowing if the divisions changed.
- `1` will conserve the existing divisions. Something like `x["attr"]` or `dak.max(x, axis=1)` conserves divisions.
- Anything greater than 1: Multiplies the existing divisions by this factor.
