### PR TITLE
Awkward behaviors support

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -3,7 +3,7 @@ from dask_awkward import config  # isort:skip; load awkward config
 from dask_awkward._version import version as __version__
 from dask_awkward.core import Array, Record, Scalar
 from dask_awkward.core import _type as type
-from dask_awkward.core import map_partitions
+from dask_awkward.core import map_partitions, with_name
 from dask_awkward.describe import fields
 from dask_awkward.io.io import (
     from_awkward,
@@ -34,7 +34,7 @@ from dask_awkward.reducers import (
     sum,
     var,
 )
-from dask_awkward.structure import (
+from dask_awkward.structure import (  # with_name,
     argcartesian,
     argcombinations,
     argsort,
@@ -68,7 +68,6 @@ from dask_awkward.structure import (
     values_astype,
     where,
     with_field,
-    with_name,
     with_parameter,
     without_parameters,
     zeros_like,

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -435,11 +435,6 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             )
         )
 
-    def possible_behavior_methods(self) -> list[str]:
-        if self._meta is None:
-            return []
-        return list(set(dir(self._meta)) - set(dir(self)) - set(dir(ak.Array)))
-
     @property
     def dask(self) -> HighLevelGraph:
         """High level task graph associated with the collection."""

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -749,7 +749,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         try:
             getattr(self._meta, method_name)
         except AttributeError:
-            raise ValueError(f"{method_name} is not available to this collection.")
+            raise AttributeError(f"{method_name} is not available to this collection.")
         return self.map_partitions(
             BehaviorCall(method_name, **kwargs),
             *args,

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -749,7 +749,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         try:
             getattr(self._meta, method_name)
         except AttributeError:
-            raise AttributeError(f"{method_name} is not available to this collection.")
+            raise AttributeError(
+                f"Method {method_name} is not available to this collection."
+            )
         return self.map_partitions(
             BehaviorCall(method_name, **kwargs),
             *args,
@@ -1404,6 +1406,17 @@ def compatible_partitions(*args: Array) -> bool:
                     return False
 
     return True
+
+
+def with_name(collection: Array, name: str) -> Array:
+    meta = ak.Array(collection._meta, with_name=name)
+    return map_partitions(
+        lambda x, n: ak.Array(x, with_name=n),
+        collection,
+        name,
+        label="with-name",
+        meta=meta,
+    )
 
 
 class BehaviorCall:

--- a/src/dask_awkward/tests/test_behavior.py
+++ b/src/dask_awkward/tests/test_behavior.py
@@ -12,10 +12,18 @@ class Point(ak.Record):
     def distance(self, other):
         return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
 
+    @property
+    def x2(self):
+        return self.x * self.x
+
 
 class PointArray(ak.Array):
     def distance(self, other):
         return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
+
+    @property
+    def x2(self):
+        return self.x * self.x
 
 
 ak.behavior["point"] = Point
@@ -53,6 +61,11 @@ def test_distance_behavior() -> None:
     )
 
 
+def test_property_behavior() -> None:
+    onedak = dak.with_name(dak.from_awkward(one, npartitions=2), "point")
+    assert_eq(onedak.x2, ak.Array(one, with_name="point").x2)
+
+
 def test_nonexistent_behavior() -> None:
     onea = ak.Array(one, with_name="point")
     twoa = ak.Array(two)
@@ -63,7 +76,13 @@ def test_nonexistent_behavior() -> None:
         AttributeError,
         match="Method doesnotexist is not available to this collection",
     ):
-        onedak._call_behavior("doesnotexist", twodak)
+        onedak._call_behavior_method("doesnotexist", twodak)
+
+    with pytest.raises(
+        AttributeError,
+        match="Property doesnotexist is not available to this collection",
+    ):
+        onedak._call_behavior_property("doesnotexist")
 
     # in this case the field check is where we raise
     with pytest.raises(AttributeError, match="distance not in fields"):

--- a/src/dask_awkward/tests/test_behavior.py
+++ b/src/dask_awkward/tests/test_behavior.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import awkward._v2 as ak
+import numpy as np
+import pytest
+
+import dask_awkward as dak
+from dask_awkward.testutils import assert_eq
+
+
+class Point(ak.Record):
+    def distance(self, other):
+        return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
+
+
+class PointArray(ak.Array):
+    def distance(self, other):
+        return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
+
+
+ak.behavior["point"] = Point
+ak.behavior[".", "point"] = PointArray
+ak.behavior["*", "point"] = PointArray
+
+one = ak.Array(
+    [
+        [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}],
+        [],
+        [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}],
+        [{"x": 6, "y": 6.6}],
+        [{"x": 7, "y": 7.7}, {"x": 8, "y": 8.8}, {"x": 9, "y": 9.9}],
+    ],
+)
+
+two = ak.Array(
+    [
+        [{"x": 0.9, "y": 1}, {"x": 2, "y": 2.2}, {"x": 2.9, "y": 3}],
+        [],
+        [{"x": 3.9, "y": 4}, {"x": 5, "y": 5.5}],
+        [{"x": 5.9, "y": 6}],
+        [{"x": 6.9, "y": 7}, {"x": 8, "y": 8.8}, {"x": 8.9, "y": 9}],
+    ],
+)
+
+
+def test_distance_behavior() -> None:
+    onedak = dak.with_name(dak.from_awkward(one, npartitions=2), "point")
+    twodak = dak.with_name(dak.from_awkward(two, npartitions=2), "point")
+
+    assert_eq(
+        onedak.distance(twodak),
+        ak.Array(one, with_name="point").distance(ak.Array(two, with_name="point")),
+    )
+
+
+def test_nonexistent_behavior() -> None:
+    onea = ak.Array(one, with_name="point")
+    twoa = ak.Array(two)
+    onedak = dak.from_awkward(onea, npartitions=2)
+    twodak = dak.from_awkward(twoa, npartitions=2)
+
+    with pytest.raises(
+        AttributeError,
+        match="Method doesnotexist is not available to this collection",
+    ):
+        onedak._call_behavior("doesnotexist", twodak)
+
+    # in this case the field check is where we raise
+    with pytest.raises(AttributeError, match="distance not in fields"):
+        twodak.distance(onedak)

--- a/src/dask_awkward/tests/test_structure.py
+++ b/src/dask_awkward/tests/test_structure.py
@@ -36,3 +36,14 @@ def test_num(daa, caa, axis) -> None:
         c1 = dak.num(da.x1, axis=axis) > 2
         c2 = ak.num(ca.x1, axis=axis) > 2
         assert_eq(da[c1], ca[c2])
+
+
+def test_zip(daa, caa) -> None:
+    da1 = daa["analysis"]["x1"]
+    da2 = daa["analysis"]["x1"]
+    ca1 = caa["analysis"]["x1"]
+    ca2 = caa["analysis"]["x1"]
+
+    da_z = dak.zip({"a": da1, "b": da2})
+    ca_z = ak.zip({"a": ca1, "b": ca2})
+    assert_eq(da_z, ca_z)

--- a/src/dask_awkward/tests/test_utils.py
+++ b/src/dask_awkward/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dask_awkward.utils import (
     LazyInputsDict,
+    hyphenize,
     is_empty_slice,
     normalize_single_outer_inner_index,
 )
@@ -64,3 +65,9 @@ def test_lazyfilesdict() -> None:
     assert list(lfd) == inputs
     assert not (5,) in lfd
     assert "a" not in lfd
+
+
+def test_hyphenize() -> None:
+    assert hyphenize("with_name") == "with-name"
+    assert hyphenize("with_a_name") == "with-a-name"
+    assert hyphenize("ok") == "ok"

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -119,3 +119,7 @@ class LazyInputsDict(collections.abc.Mapping):
 
     def keys(self):
         return ((i,) for i in range(len(self.inputs)))
+
+
+def hyphenize(x: str) -> str:
+    return x.replace("_", "-")

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -93,11 +93,28 @@ def borrow_docstring(original: Callable) -> Callable:
 
 
 def empty_typetracer() -> ak.Array:
+    """Instantiate a typetracer array with unknown length.
+
+    Returns
+    -------
+    ak.Array
+        Length-less typetracer array (content-less array).
+
+    """
     a = ak.Array([])
     return ak.Array(a.layout.typetracer.forget_length())
 
 
 class LazyInputsDict(collections.abc.Mapping):
+    """Dictionary with lazy key value pairs
+
+    Parameters
+    ----------
+    inputs : list[Any]
+        The list of dicionary values.
+
+    """
+
     def __init__(self, inputs: list[Any], **kwargs: Any) -> None:
         self.inputs = inputs
         self.kwargs = kwargs
@@ -122,4 +139,12 @@ class LazyInputsDict(collections.abc.Mapping):
 
 
 def hyphenize(x: str) -> str:
+    """Replace underscores with hyphens.
+
+    Returns
+    -------
+    str
+        Resulting strings with hyphens replacing underscores.
+
+    """
     return x.replace("_", "-")


### PR DESCRIPTION
- [x] Add a function which serves as an equivalent for `x = ak.Array(x, with_name="foo")` but for collections.
- [x] Give the `Array` collection the ability to find behaviors attached to its metadata and call with `map_partitions`.
- [ ] ~~Find a way to communicate `ak.behavior` table when using `distributed` scheduler.~~ will address in a subsequent PR