### PR TITLE
Misc dev.

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -9,6 +9,7 @@ from dask_awkward.io.io import (
     from_awkward,
     from_dask_array,
     from_delayed,
+    from_map,
     to_dask_array,
     to_delayed,
 )

--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -1,2 +1,15 @@
 awkward:
+
+  # This option is for cases where new array collections are created
+  # with unknown metadata. The default setting is to compute the first
+  # partition of the colleciton so that we can define the metadata. If
+  # this option is set to False then collections with unknown metadata
+  # will be instantiated with the `_meta` attribute set to `None`.
   compute-unknown-meta: True
+
+  # The scheduler to use when computing the first partition. The
+  # default setting (undefined, Python's `None`), will use Dask's
+  # current default global scheduler. That is, if you are using a
+  # distributed scheduler then that scheduler will be used. See the
+  # documentation for `dask.compute` for all options.
+  first-partition-scheduler: null

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -1433,10 +1433,8 @@ def compatible_partitions(*args: Array) -> bool:
 def with_name(collection: Array, name: str, behavior: dict | None = None) -> Array:
     meta = ak.Array(collection._meta, with_name=name, behavior=behavior)
     return map_partitions(
-        lambda c, n, b: ak.Array(c, with_name=n, behavior=b),
+        lambda c: ak.Array(c, with_name=name, behavior=behavior),
         collection,
-        name,
-        behavior,
         label="with-name",
         meta=meta,
     )

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -330,9 +330,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         self._dask: HighLevelGraph = dsk
         self._name: str = name
         self._divisions = divisions
-        if meta is None:
-            self._meta: ak.Array = empty_typetracer()
-        elif not isinstance(meta, (ak.Array, TypeTracerArray)):
+        if meta is not None and not isinstance(meta, (ak.Array, TypeTracerArray)):
             raise TypeError("meta must be an instance of an Awkward Array.")
         self._meta = meta
 
@@ -474,7 +472,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     def layout(self) -> Content:
         if self._meta is not None:
             return self._meta.layout
-        raise ValueError("This collections meta is None; unknown layout.")
+        raise ValueError("This collection's meta is None; unknown layout.")
 
     @property
     def _typetracer(self) -> ak.Array:
@@ -487,7 +485,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     @property
     def form(self) -> Form:
-        return self._meta.layout.form
+        if self._meta is not None:
+            return self._meta.layout.form
+        raise ValueError("This collection's meta is None; unknown form.")
 
     @cached_property
     def keys_array(self) -> np.ndarray:
@@ -916,11 +916,12 @@ def _first_partition(array: Array) -> ak.Array:
 
     """
     with dask.config.set({"awkward.compute-unknown-meta": False}):
+        scheduler = dask.config.get("awkward.first-partition-scheduler")
         (computed,) = dask_compute(
             array.partitions[0],
             traverse=False,
             optimize_graph=True,
-            scheduler="threads",
+            scheduler=scheduler,
         )
         return computed
 
@@ -990,7 +991,7 @@ def new_array_object(
 
     array = Array(dsk, name, meta, divisions)  # type: ignore
 
-    if meta is None:
+    if array._meta is None:
         if dask.config.get("awkward.compute-unknown-meta"):
             try:
                 array._meta = _get_typetracer(array)

--- a/src/dask_awkward/io/io.py
+++ b/src/dask_awkward/io/io.py
@@ -311,6 +311,7 @@ def from_map(
     if not callable(func):
         raise ValueError("`func` argument must be `callable`")
     lengths = set()
+    iterables = list(iterables)
     for i, iterable in enumerate(iterables):
         if not isinstance(iterable, Iterable):
             raise ValueError(
@@ -318,7 +319,7 @@ def from_map(
             )
         try:
             lengths.add(len(iterable))
-        except AttributeError:
+        except (AttributeError, TypeError):
             iterables[i] = list(iterable)  # type: ignore
             lengths.add(len(iterables[i]))
     if len(lengths) == 0:

--- a/src/dask_awkward/io/io.py
+++ b/src/dask_awkward/io/io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 from collections.abc import Sequence
 from math import ceil
 from typing import TYPE_CHECKING, Any, Callable
@@ -33,7 +32,7 @@ class FromAwkwardWrapper:
 
     def __call__(self, source: tuple[Any, ...]) -> ak.Array:
         start, stop = source[0]
-        return copy.copy(self.arr[start:stop])
+        return self.arr[start:stop]
 
 
 def from_awkward(source: ak.Array, npartitions: int, name: str | None = None) -> Array:

--- a/src/dask_awkward/io/io.py
+++ b/src/dask_awkward/io/io.py
@@ -343,6 +343,9 @@ def from_map(
         inputs = iterables[0]
         packed = False
     else:
+        # Structure inputs such that the tuple of arguments pair each 0th,
+        # 1st, 2nd, ... elements together; for example:
+        # from_map(f, [1, 2, 3], [4, 5, 6]) --> [f(1, 4), f(2, 5), f(3, 6)]
         inputs = list(zip(*iterables))
         packed = True
 
@@ -361,11 +364,6 @@ def from_map(
         )
     else:
         io_func = func
-
-    # Structure inputs such that the tuple of arguments pair each 0th,
-    # 1st, 2nd, ... elements together; for example:
-    # from_map(f, [1, 2, 3], [4, 5, 6]) --> [f(1, 4), f(2, 5), f(3, 6)]
-    # inputs = list(zip(*iterables))
 
     io_arg_map = BlockwiseDepDict(
         mapping=LazyInputsDict(inputs),  # type: ignore

--- a/src/dask_awkward/io/io.py
+++ b/src/dask_awkward/io/io.py
@@ -203,39 +203,39 @@ def from_dask_array(array: DaskArray) -> Array:
         return new_array_object(hlg, name, divisions=divs, meta=meta)
 
 
-class AwkwardIOLayer(Blockwise):
-    def __init__(
-        self,
-        name: str,
-        inputs: Any,
-        io_func: Callable,
-        label: str | None = None,
-        produces_tasks: bool = False,
-        creation_info: dict | None = None,
-        annotations: dict | None = None,
-    ):
-        self.name = name
-        self.inputs = inputs
-        self.io_func = io_func
-        self.label = label
-        self.produces_tasks = produces_tasks
-        self.annotations = annotations
-        self.creation_info = creation_info
+# class AwkwardIOLayer(Blockwise):
+#     def __init__(
+#         self,
+#         name: str,
+#         inputs: Any,
+#         io_func: Callable,
+#         label: str | None = None,
+#         produces_tasks: bool = False,
+#         creation_info: dict | None = None,
+#         annotations: dict | None = None,
+#     ):
+#         self.name = name
+#         self.inputs = inputs
+#         self.io_func = io_func
+#         self.label = label
+#         self.produces_tasks = produces_tasks
+#         self.annotations = annotations
+#         self.creation_info = creation_info
 
-        io_arg_map = BlockwiseDepDict(
-            mapping=LazyInputsDict(self.inputs),  # type: ignore
-            produces_tasks=self.produces_tasks,
-        )
+#         io_arg_map = BlockwiseDepDict(
+#             mapping=LazyInputsDict(self.inputs),  # type: ignore
+#             produces_tasks=self.produces_tasks,
+#         )
 
-        dsk = {self.name: (io_func, blockwise_token(0))}
-        super().__init__(
-            output=self.name,
-            output_indices="i",
-            dsk=dsk,
-            indices=[(io_arg_map, "i")],
-            numblocks={},
-            annotations=annotations,
-        )
+#         dsk = {self.name: (io_func, blockwise_token(0))}
+#         super().__init__(
+#             output=self.name,
+#             output_indices="i",
+#             dsk=dsk,
+#             indices=[(io_arg_map, "i")],
+#             numblocks={},
+#             annotations=annotations,
+#         )
 
 
 def from_map(
@@ -284,8 +284,6 @@ def from_map(
 
     inputs = list(zip(*iterables))
 
-    deps: set[Any] | list[Any] = set()
-
     # dsk: Mapping = AwkwardIOLayer(
     #     name,
     #     inputs,
@@ -308,7 +306,7 @@ def from_map(
         annotations=None,
     )
 
-    hlg = HighLevelGraph.from_collections(name, dsk, dependencies=deps)
+    hlg = HighLevelGraph.from_collections(name, dsk)
     if divisions is not None:
         return new_array_object(hlg, name, meta=meta, divisions=divisions)
     else:

--- a/src/dask_awkward/io/io.py
+++ b/src/dask_awkward/io/io.py
@@ -28,12 +28,12 @@ if TYPE_CHECKING:
 
 
 class FromAwkwardWrapper:
-    def __init__(self, array: ak.Array) -> None:
-        self.array = array
+    def __init__(self, arr: ak.Array) -> None:
+        self.arr = arr
 
     def __call__(self, source: tuple[Any, ...]) -> ak.Array:
         start, stop = source[0]
-        return copy.copy(self.array[start:stop])
+        return copy.copy(self.arr[start:stop])
 
 
 def from_awkward(source: ak.Array, npartitions: int, name: str | None = None) -> Array:

--- a/src/dask_awkward/io/json.py
+++ b/src/dask_awkward/io/json.py
@@ -245,8 +245,7 @@ def from_json(
         else:
             f = FromJsonLineDelimitedWrapper(storage=fs, compression=compression)
 
-        parts = [(x,) for x in urlpaths]
-        return from_map(f, parts, label="from-json", meta=meta)
+        return from_map(f, urlpaths, label="from-json", meta=meta)
 
     # if a `delimiter` and `blocksize` are defined we use Dask's
     # `read_bytes` function to get delayed chunks of bytes.

--- a/src/dask_awkward/io/json.py
+++ b/src/dask_awkward/io/json.py
@@ -56,7 +56,7 @@ class FromJsonLineDelimitedWrapper(FromJsonWrapper):
 
     def __call__(self, source: str, *args: Any, **kwargs: Any) -> ak.Array:
         with self.storage.open(source, mode="rt", compression=self.compression) as f:
-            return ak.from_iter(json.loads(line) for line in f)
+            return ak.from_json(f.read())
 
 
 class FromJsonSingleObjInFileWrapper(FromJsonWrapper):

--- a/src/dask_awkward/io/scratch.py
+++ b/src/dask_awkward/io/scratch.py
@@ -29,7 +29,7 @@ class FromParquetWrapper:
         self.kwargs = kwargs
 
     def __call__(self, part: Any) -> ak.Array:
-        source = part
+        source = part[0]
         source = fsspec.utils._unstrip_protocol(source, self.fs)
         return ak.from_parquet(
             source,
@@ -48,6 +48,7 @@ def from_parquet(
         urlpath,
         storage_options=storage_options,
     )
+
     return from_map(
         FromParquetWrapper(storage=fs, **kwargs),
         paths,

--- a/src/dask_awkward/io/scratch.py
+++ b/src/dask_awkward/io/scratch.py
@@ -28,8 +28,7 @@ class FromParquetWrapper:
         self.fs = storage
         self.kwargs = kwargs
 
-    def __call__(self, part: Any) -> ak.Array:
-        source = part[0]
+    def __call__(self, source: Any) -> ak.Array:
         source = fsspec.utils._unstrip_protocol(source, self.fs)
         return ak.from_parquet(
             source,

--- a/src/dask_awkward/reducers.py
+++ b/src/dask_awkward/reducers.py
@@ -5,8 +5,6 @@ import numpy as np
 
 from dask_awkward.core import (
     DaskAwkwardNotImplemented,
-    IncompatiblePartitions,
-    compatible_partitions,
     map_partitions,
     pw_reduction_with_agg_to_scalar,
 )
@@ -190,8 +188,6 @@ def covar(
     mask_identity=True,
     flatten_records=False,
 ):
-    if not compatible_partitions(x, y):
-        raise IncompatiblePartitions("covar", x, y)
     raise DaskAwkwardNotImplemented("TODO")
 
 
@@ -205,8 +201,6 @@ def linear_fit(
     mask_identity=True,
     flatten_records=False,
 ):
-    if not compatible_partitions(x, y):
-        raise IncompatiblePartitions("linear_fit", x, y)
     raise DaskAwkwardNotImplemented("TODO")
 
 

--- a/src/dask_awkward/reducers.py
+++ b/src/dask_awkward/reducers.py
@@ -105,8 +105,6 @@ def corr(
     mask_identity=True,
     flatten_records=False,
 ):
-    if not compatible_partitions(x, y):
-        raise IncompatiblePartitions("corr", x, y)
     raise DaskAwkwardNotImplemented("TODO")
 
 
@@ -336,22 +334,7 @@ def std(
     mask_identity=True,
     flatten_records=False,
 ):
-    if weight is not None:
-        raise DaskAwkwardNotImplemented("dak.std with weights is not supported yet.")
-
-    if axis == 1:
-        return map_partitions(
-            ak.std,
-            x,
-            output_divisions=1,
-            weight=weight,
-            ddof=ddof,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            flatten_records=flatten_records,
-        )
-    raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
+    raise DaskAwkwardNotImplemented("TODO")
 
 
 @borrow_docstring(ak.sum)

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -10,8 +10,6 @@ import numpy as np
 from dask_awkward.core import (
     Array,
     DaskAwkwardNotImplemented,
-    IncompatiblePartitions,
-    compatible_partitions,
     map_partitions,
     new_known_scalar,
     pw_reduction_with_agg_to_scalar,
@@ -203,16 +201,17 @@ def local_index(array, axis=-1, highlevel: bool = True, behavior=None):
 
 @borrow_docstring(ak.mask)
 def mask(array, mask, valid_when=True, highlevel: bool = True, behavior=None):
-    if not compatible_partitions(array, mask):
-        raise IncompatiblePartitions("mask", array, mask)
-    return map_partitions(
-        ak.mask,
-        array,
-        mask,
-        valid_when=valid_when,
-        highlevel=highlevel,
-        behavior=behavior,
-    )
+    # if not compatible_partitions(array, mask):
+    #     raise IncompatiblePartitions("mask", array, mask)
+    # return map_partitions(
+    #     ak.mask,
+    #     array,
+    #     mask,
+    #     valid_when=valid_when,
+    #     highlevel=highlevel,
+    #     behavior=behavior,
+    # )
+    raise DaskAwkwardNotImplemented("TODO")
 
 
 @borrow_docstring(ak.nan_to_num)
@@ -225,17 +224,18 @@ def nan_to_num(
     highlevel: bool = True,
     behavior: Any | None = None,
 ):
-    return map_partitions(
-        ak.nan_to_num,
-        array,
-        output_partitions=1,
-        copy=copy,
-        nan=nan,
-        posinf=posinf,
-        neginf=neginf,
-        highlevel=highlevel,
-        behavior=behavior,
-    )
+    # return map_partitions(
+    #     ak.nan_to_num,
+    #     array,
+    #     output_partitions=1,
+    #     copy=copy,
+    #     nan=nan,
+    #     posinf=posinf,
+    #     neginf=neginf,
+    #     highlevel=highlevel,
+    #     behavior=behavior,
+    # )
+    raise DaskAwkwardNotImplemented("TODO")
 
 
 @borrow_docstring(ak.num)

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -85,6 +85,14 @@ def test_boolean_array(line_delim_records_file, op) -> None:
     assert_eq(dx1_p, cx1_p)
 
 
+def test_boolean_array_from_awkward(line_delim_records_file) -> None:
+    daa = dak.from_json([line_delim_records_file] * 3)
+    cx1_2 = daa.analysis.x1.compute()
+    dx1_2 = dak.from_awkward(cx1_2, npartitions=6)
+    dx1_2 = dx1_2[dx1_2 > 2]
+    assert_eq(dx1_2, cx1_2[cx1_2 > 2])
+
+
 def test_tuple_boolean_array_raise(line_delim_records_file) -> None:
     daa = dak.from_json([line_delim_records_file] * 2)
     sel = dak.num(daa.analysis.x1, axis=1) >= 2

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -153,6 +153,19 @@ def test_from_map_pack_single_iterable(line_delim_records_file) -> None:
     assert_eq(x, y)
 
 
+def test_from_map_enumerate() -> None:
+    def f(t):
+        i = t[0]
+        x = t[1]
+        return ak.Array([{"x": (i + 1) * x}])
+
+    x = [[1, 2, 3], [4, 5, 6]]
+
+    a1 = dak.from_map(f, enumerate(x))
+    a2 = ak.Array([{"x": [1, 2, 3]}, {"x": [4, 5, 6, 4, 5, 6]}])
+    assert_eq(a1, a2)
+
+
 def test_from_map_exceptions():
     def f(a, b):
         return ak.Array([a, b])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import awkward._v2 as ak
 import fsspec
 import pytest
@@ -134,6 +136,20 @@ def test_from_map_with_args_kwargs() -> None:
     y = map(lambda x: x * n, y)
     y = ak.from_iter(y)
 
+    assert_eq(x, y)
+
+
+def test_from_map_pack_single_iterable(line_delim_records_file) -> None:
+    def g(fname, c=1):
+        return ak.from_json(Path(fname).read_text()).analysis.x1 * c
+
+    n = 3
+    c = 2
+
+    fmt = "{t}\n" * n
+    jsontext = fmt.format(t=Path(line_delim_records_file).read_text())
+    x = dak.from_map(g, [line_delim_records_file] * n, c=c)
+    y = ak.from_json(jsontext).analysis.x1 * c
     assert_eq(x, y)
 
 


### PR DESCRIPTION
- Use regular `Blockwise` layer instead of `AwkwardIOLayer` (which inherits from `Blockwise`); this fixes serialization issues with `distributed`.
- Improvements to `from_map`; larger surface area of support (better/clearer support for multiple iterables being passed to the callable, supprt for additional args being passed to the callable)
- start using `awkward._v2.from_json`
- Remove some old untested code prototype code (back to raising a NotImplemented TODO)
- Add a new option to the config setup related to the first partition compute (`awkward.first-partition-scheduler`); default will use whatever Dask's global scheduler is at that moment.