### PR TITLE
General development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ src_paths = ["src", "tests"]
 
 [tool.mypy]
 python_version = "3.8"
-files = ["src"]
+files = ["src", "tests"]
 warn_unused_configs = true
 show_error_codes = true
 

--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -3,7 +3,7 @@ from dask_awkward import config  # isort:skip; load awkward config
 from dask_awkward._version import version as __version__
 from dask_awkward.core import Array, Record, Scalar
 from dask_awkward.core import _type as type
-from dask_awkward.core import map_partitions, with_name
+from dask_awkward.core import map_partitions
 from dask_awkward.describe import fields
 from dask_awkward.io.io import (
     from_awkward,
@@ -70,6 +70,7 @@ from dask_awkward.structure import (
     values_astype,
     where,
     with_field,
+    with_name,
     with_parameter,
     without_parameters,
     zeros_like,

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -290,6 +290,12 @@ class Record(Scalar):
             return ak.fields(self._meta)
         return None
 
+    @property
+    def layout(self) -> Any:
+        if self._meta is not None:
+            return self._meta.layout
+        raise ValueError("This collection's meta is None; unknown layout.")
+
     def _ipython_key_completions_(self) -> list[str]:
         if self._meta is not None:
             return self._meta._ipython_key_completions_()

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -176,7 +176,7 @@ class Scalar(DaskMethodsMixin):
         return self.__str__()
 
     def __str__(self) -> str:
-        dt = str(self.dtype) or "Unknown"
+        dt = self.dtype or "Unknown"
         if self.known_value is not None:
             return (
                 f"dask.awkward<{key_split(self.name)}, "
@@ -217,6 +217,8 @@ def new_known_scalar(
             dtype = np.dtype(float)
         else:
             dtype = np.dtype(type(s))
+    else:
+        dtype = np.dtype(dtype)
     llg = {name: s}
     hlg = HighLevelGraph.from_collections(name, llg, dependencies=())
     return Scalar(hlg, name, meta=UnknownScalar(dtype), known_value=s)

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import keyword
 import operator
 import warnings
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from functools import cached_property, partial
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Hashable, Mapping, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import awkward._v2 as ak
 import dask.config

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -1444,16 +1444,6 @@ def compatible_partitions(*args: Array) -> bool:
     return True
 
 
-def with_name(collection: Array, name: str, behavior: dict | None = None) -> Array:
-    meta = ak.Array(collection._meta, with_name=name, behavior=behavior)
-    return map_partitions(
-        lambda c: ak.Array(c, with_name=name, behavior=behavior),
-        collection,
-        label="with-name",
-        meta=meta,
-    )
-
-
 class BehaviorMethodCall:
     def __init__(self, attr: str, **kwargs: Any) -> None:
         self.attr = attr

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -98,7 +98,7 @@ class Scalar(DaskMethodsMixin):
     def __dask_graph__(self) -> HighLevelGraph:
         return self._dask
 
-    def __dask_keys__(self) -> list[str]:
+    def __dask_keys__(self) -> list[Hashable]:
         return [self._name]
 
     def __dask_layers__(self) -> tuple[str, ...]:
@@ -349,7 +349,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     def __dask_graph__(self) -> HighLevelGraph:
         return self.dask
 
-    def __dask_keys__(self) -> list[tuple[str, int]]:
+    def __dask_keys__(self) -> list[Hashable]:
         return [(self.name, i) for i in range(self.npartitions)]
 
     def __dask_layers__(self) -> tuple[str]:
@@ -451,7 +451,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         return self._dask
 
     @property
-    def keys(self) -> list[tuple[str, int]]:
+    def keys(self) -> list[Hashable]:
         """Task graph keys."""
         return self.__dask_keys__()
 

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -425,7 +425,7 @@ def zeros_like(array, highlevel: bool = True, behavior=None, dtype=None):
     raise DaskAwkwardNotImplemented("TODO")
 
 
-class _ZipWrapper:
+class _ZipFn:
     def __init__(self, keys: Sequence[str], **kwargs) -> None:
         self.keys = keys
         self.kwargs = kwargs
@@ -469,7 +469,7 @@ def zip(
     )
 
     return map_partitions(
-        _ZipWrapper(
+        _ZipFn(
             keys,
             depth_limit=depth_limit,
             parameters=parameters,

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import builtins
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import awkward._v2 as ak
 import numpy as np

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -105,6 +105,14 @@ def broadcast_arrays(*arrays, **kwargs):
     raise DaskAwkwardNotImplemented("TODO")
 
 
+class _CartesianWrapper:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, *arrays):
+        return ak.cartesian(list(arrays), **self.kwargs)
+
+
 @borrow_docstring(ak.cartesian)
 def cartesian(
     arrays,
@@ -115,6 +123,16 @@ def cartesian(
     highlevel: bool = True,
     behavior=None,
 ):
+    if axis == 1:
+        fn = _CartesianWrapper(
+            axis=axis,
+            nested=nested,
+            parameters=parameters,
+            with_name=with_name,
+            highlevel=highlevel,
+            behavior=behavior,
+        )
+        return map_partitions(fn, *arrays, label="cartesian")
     raise DaskAwkwardNotImplemented("TODO")
 
 

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -132,7 +132,7 @@ def cartesian(
             highlevel=highlevel,
             behavior=behavior,
         )
-        return map_partitions(fn, *arrays, label="cartesian")
+        return map_partitions(fn, *arrays, label="cartesian", output_divisions=1)
     raise DaskAwkwardNotImplemented("TODO")
 
 

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -179,7 +179,12 @@ def firsts(array, axis: int | None = 1, highlevel: bool = True, behavior=None):
 
 
 @borrow_docstring(ak.flatten)
-def flatten(array, axis: int | None = 1, highlevel: bool = True, behavior=None):
+def flatten(
+    array: Array,
+    axis: int | None = 1,
+    highlevel: bool = True,
+    behavior: dict | None = None,
+) -> Array:
     return map_partitions(
         ak.flatten,
         array,
@@ -288,8 +293,22 @@ def num(
 
 
 @borrow_docstring(ak.ones_like)
-def ones_like(array, highlevel: bool = True, behavior=None, dtype=None):
-    raise DaskAwkwardNotImplemented("TODO")
+def ones_like(
+    array: ak.Array,
+    highlevel: bool = True,
+    behavior: dict | None = None,
+    dtype=None,
+) -> Array:
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+    return map_partitions(
+        ak.ones_like,
+        array,
+        output_divisions=1,
+        label="ones-like",
+        behavior=behavior,
+        dtype=dtype,
+    )
 
 
 @borrow_docstring(ak.packed)
@@ -367,8 +386,21 @@ def with_field(base, what, where=None, highlevel: bool = True, behavior=None):
 
 
 @borrow_docstring(ak.with_name)
-def with_name(array, name, highlevel: bool = True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+def with_name(
+    array: Array,
+    name: str,
+    highlevel: bool = True,
+    behavior: dict | None = None,
+) -> Array:
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+    meta = ak.Array(array._meta, with_name=name, behavior=behavior)
+    return map_partitions(
+        lambda c: ak.Array(c, with_name=name, behavior=behavior),
+        array,
+        label="with-name",
+        meta=meta,
+    )
 
 
 @borrow_docstring(ak.with_parameter)

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import Any, Sequence
 
 import awkward._v2 as ak
 import numpy as np
@@ -14,9 +14,6 @@ from dask_awkward.core import (
     pw_reduction_with_agg_to_scalar,
 )
 from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
-
-if TYPE_CHECKING:
-    from awkward._v2.highlevel import Array as AwkwardArray
 
 __all__ = (
     "argcartesian",
@@ -430,7 +427,7 @@ class _ZipFn:
         self.keys = keys
         self.kwargs = kwargs
 
-    def __call__(self, *parts: Array) -> AwkwardArray:
+    def __call__(self, *parts: ak.Array) -> ak.Array:
         return ak.zip(
             {k: p for k, p in builtins.zip(self.keys, list(parts))},
             **self.kwargs,

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -335,7 +335,7 @@ def num(
 
 @borrow_docstring(ak.ones_like)
 def ones_like(
-    array: ak.Array,
+    array: Array,
     highlevel: bool = True,
     behavior: dict | None = None,
     dtype: DTypeLike | None = None,
@@ -503,6 +503,9 @@ def zip(
     right_broadcast: bool = False,
     optiontype_outside_record: bool = False,
 ):
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
     if not isinstance(arrays, dict):
         raise DaskAwkwardNotImplemented("ak.zip only supports dictionary inputs.")
 

--- a/src/dask_awkward/structure.py
+++ b/src/dask_awkward/structure.py
@@ -18,6 +18,8 @@ from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
+    from dask_awkward.typing import AwkwardDaskCollection
+
 __all__ = (
     "argcartesian",
     "argcombinations",
@@ -187,7 +189,7 @@ def firsts(
     axis: int | None = 1,
     highlevel: bool = True,
     behavior: dict | None = None,
-) -> Array:
+) -> AwkwardDaskCollection:
     if axis == 1:
         return map_partitions(
             _FirstsFn(

--- a/src/dask_awkward/testutils.py
+++ b/src/dask_awkward/testutils.py
@@ -7,6 +7,7 @@ import awkward._v2 as ak
 from dask.base import is_dask_collection
 
 from dask_awkward.core import Array, Record, typetracer_array
+from dask_awkward.io.io import from_lists
 
 _RG = random.Random(414)
 
@@ -145,7 +146,41 @@ def list_of_xy_points(n: int) -> list[dict[str, int]]:
     return [make_xy_point() for _ in range(n)]
 
 
-def awkward_xy_points(lengths: tuple[int, ...] | None = None):
+def awkward_xy_points(lengths: tuple[int, ...] | None = None) -> ak.Array:
     if lengths is None:
         lengths = (3, 0, 2, 1, 3)
     return ak.Array([list_of_xy_points(n) for n in lengths])
+
+
+def list1() -> list:
+    return [
+        [{"x": 1.0, "y": 1.1}, {"x": 2.0, "y": 2.2}, {"x": 3, "y": 3.3}],
+        [],
+        [{"x": 4.0, "y": 4.4}, {"x": 5.0, "y": 5.5}],
+        [{"x": 6.0, "y": 6.6}],
+        [{"x": 7.0, "y": 7.7}, {"x": 8.0, "y": 8.8}, {"x": 9, "y": 9.9}],
+    ]
+
+
+def list2() -> list:
+    return [
+        [{"x": 0.9, "y": 1.0}, {"x": 2.0, "y": 2.2}, {"x": 2.9, "y": 3.0}],
+        [],
+        [{"x": 3.9, "y": 4.0}, {"x": 5.0, "y": 5.5}],
+        [{"x": 5.9, "y": 6.0}],
+        [{"x": 6.9, "y": 7.0}, {"x": 8.0, "y": 8.8}, {"x": 8.9, "y": 9.0}],
+    ]
+
+
+def list3() -> list:
+    return [
+        [{"x": 1.9, "y": 9.0}, {"x": 2.0, "y": 8.2}, {"x": 9.9, "y": 9.0}],
+        [],
+        [{"x": 1.9, "y": 8.0}, {"x": 4.0, "y": 6.5}],
+        [{"x": 1.9, "y": 7.0}],
+        [{"x": 1.9, "y": 6.0}, {"x": 6.0, "y": 4.8}, {"x": 9.9, "y": 9.0}],
+    ]
+
+
+def lists() -> ak.Array:
+    return from_lists([list1(), list2(), list3()])

--- a/src/dask_awkward/testutils.py
+++ b/src/dask_awkward/testutils.py
@@ -159,7 +159,7 @@ def list1() -> list:
         [{"x": 4.0, "y": 4.4}, {"x": 5.0, "y": 5.5}],
         [{"x": 6.0, "y": 6.6}],
         [{"x": 7.0, "y": 7.7}, {"x": 8.0, "y": 8.8}, {"x": 9, "y": 9.9}],
-    ]
+    ]  # pragma: no cover
 
 
 def list2() -> list:
@@ -169,7 +169,7 @@ def list2() -> list:
         [{"x": 3.9, "y": 4.0}, {"x": 5.0, "y": 5.5}],
         [{"x": 5.9, "y": 6.0}],
         [{"x": 6.9, "y": 7.0}, {"x": 8.0, "y": 8.8}, {"x": 8.9, "y": 9.0}],
-    ]
+    ]  # pragma: no cover
 
 
 def list3() -> list:
@@ -179,8 +179,8 @@ def list3() -> list:
         [{"x": 1.9, "y": 8.0}, {"x": 4.0, "y": 6.5}],
         [{"x": 1.9, "y": 7.0}],
         [{"x": 1.9, "y": 6.0}, {"x": 6.0, "y": 4.8}, {"x": 9.9, "y": 9.0}],
-    ]
+    ]  # pragma: no cover
 
 
 def lists() -> ak.Array:
-    return from_lists([list1(), list2(), list3()])
+    return from_lists([list1(), list2(), list3()])  # pragma: no cover

--- a/src/dask_awkward/typing.py
+++ b/src/dask_awkward/typing.py
@@ -14,6 +14,9 @@ except ImportError:
 
 @runtime_checkable
 class AwkwardDaskCollection(HLGDaskCollection, Protocol):
+
+    _meta: Any
+
     @property
     @abc.abstractmethod
     def fields(self) -> list[str]:
@@ -27,4 +30,12 @@ class AwkwardDaskCollection(HLGDaskCollection, Protocol):
     @property
     @abc.abstractmethod
     def npartitions(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def __getitem__(self, where: Any) -> AwkwardDaskCollection:
+        pass
+
+    @abc.abstractmethod
+    def __getattr__(self, attr: str) -> Any:
         pass

--- a/src/dask_awkward/typing.py
+++ b/src/dask_awkward/typing.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import abc
+from typing import Any, Protocol, runtime_checkable
+
+try:
+    from dask.typing import HLGDaskCollection
+except ImportError:
+    raise ImportError(
+        "Using dask-awkward's typing module requires a version "
+        "of Dask with support for the dask.typing module."
+    )
+
+
+@runtime_checkable
+class AwkwardDaskCollection(HLGDaskCollection, Protocol):
+    @property
+    @abc.abstractmethod
+    def fields(self) -> list[str]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def layout(self) -> Any:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def npartitions(self) -> int:
+        pass

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import collections.abc
-from typing import Any, Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import awkward._v2 as ak
 import numpy as np
@@ -32,7 +32,7 @@ class IncompatiblePartitions(ValueError):
         return msg
 
 
-class LazyInputsDict(collections.abc.Mapping):
+class LazyInputsDict(Mapping):
     """Dictionary with lazy key value pairs
 
     Parameters

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -9,7 +9,7 @@ from awkward._v2.behaviors.mixins import mixin_class_method as ak_mixin_class_me
 import dask_awkward as dak
 from dask_awkward.testutils import assert_eq
 
-behaviors = {}
+behaviors: dict = {}
 
 
 @ak_mixin_class(behaviors)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -331,6 +331,16 @@ def test_scalar_repr(daa: dakc.Array) -> None:
     s = dak.max(daa.points.y)
     sstr = str(s)
     assert "type=Scalar" in sstr
+    s = dakc.new_known_scalar(5)
+    sstr = str(s)
+    assert (
+        sstr == r"dask.awkward<known-scalar, type=Scalar, dtype=int64, known_value=5>"
+    )
+
+
+def test_scalar_divisions(daa: dakc.Array) -> None:
+    s = dak.max(daa.points.x, axis=None)
+    assert s.divisions == (None, None)
 
 
 def test_array_persist(daa: dakc.Array) -> None:
@@ -339,11 +349,19 @@ def test_array_persist(daa: dakc.Array) -> None:
     daa2 = daa.persist()
     assert_eq(daa2, daa)
 
+    import dask
 
-def test_scalar_persist(daa: dakc.Array) -> None:
+    dask.persist
+
+
+def test_scalar_persist_and_rebuild(daa: dakc.Array) -> None:
     coll = daa["points"][0]["x"][0]
     coll2 = coll.persist()
     assert_eq(coll, coll2)
+
+    m = dak.max(daa.points.x, axis=None)
+    rebuilt = m._rebuild(m.dask, rename={m._name: "max2"})
+    assert "max2" == str(rebuilt.__dask_keys__()[0])
 
 
 def test_output_divisions(daa: dakc.Array) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -349,10 +349,6 @@ def test_array_persist(daa: dakc.Array) -> None:
     daa2 = daa.persist()
     assert_eq(daa2, daa)
 
-    import dask
-
-    dask.persist
-
 
 def test_scalar_persist_and_rebuild(daa: dakc.Array) -> None:
     coll = daa["points"][0]["x"][0]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     import json  # type: ignore
 
+import sys
+
 import dask_awkward as dak
 import dask_awkward.core as dakc
 from dask_awkward.testutils import assert_eq
@@ -327,6 +329,7 @@ def test_bad_meta_type(ndjson_points_file: str, meta) -> None:
         dak.from_json([ndjson_points_file] * 3, meta=meta)
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="skip if windows")
 def test_scalar_repr(daa: dakc.Array) -> None:
     s = dak.max(daa.points.y)
     sstr = str(s)

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -82,7 +82,7 @@ def test_from_delayed(loop, ndjson_points_file: str) -> None:  # noqa
 from awkward._v2.behaviors.mixins import mixin_class as ak_mixin_class
 from awkward._v2.behaviors.mixins import mixin_class_method as ak_mixin_class_method
 
-behaviors = {}
+behaviors: dict = {}
 
 
 @ak_mixin_class(behaviors)

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -96,8 +96,8 @@ def test_boolean_array(daa: dak.Array, op: Callable) -> None:
 def test_boolean_array_from_awkward(daa: dak.Array) -> None:
     cx_2 = daa.points.x.compute()
     dx_2 = dak.from_awkward(cx_2, npartitions=6)
-    dx_2 = dx_2[dx_2 > 2]
-    assert_eq(dx_2, cx_2[cx_2 > 2])
+    dx_3 = dx_2[dx_2 > 2]
+    assert_eq(dx_3, cx_2[cx_2 > 2])
 
 
 def test_tuple_boolean_array_raise(daa: dak.Array) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -83,7 +83,7 @@ def test_from_dask_array() -> None:
 
 @pytest.mark.parametrize("optimize_graph", [True, False])
 def test_to_and_from_delayed(daa: dak.Array, optimize_graph: bool) -> None:
-    daa = daa[dak.num(daa.points.x, axis=1) > 2]
+    daa = daa[dak.num(daa.points.x, axis=1) > 2]  # type: ignore
     delayeds = daa.to_delayed(optimize_graph=optimize_graph)
     daa2 = dak.from_delayed(delayeds)
     assert_eq(daa, daa2)
@@ -116,9 +116,9 @@ def test_from_map_with_args_kwargs() -> None:
 
     # concrete version
     y = list(zip(a, b, c))
-    y = dask.core.flatten(list(map(list, y)))
-    y = map(lambda x: x * n, y)
-    y = ak.from_iter(y)
+    y = dask.core.flatten(list(map(list, y)))  # type: ignore
+    y = map(lambda x: x * n, y)  # type: ignore
+    y = ak.from_iter(y)  # type: ignore
 
     assert_eq(x, y)
 
@@ -126,10 +126,10 @@ def test_from_map_with_args_kwargs() -> None:
     x = dak.from_map(f, a, b, c, args=(n,), pad_zero=True)
 
     # concrete version
-    y = list(zip(a, b, c, [0, 0, 0]))
-    y = dask.core.flatten(list(map(list, y)))
-    y = map(lambda x: x * n, y)
-    y = ak.from_iter(y)
+    y = list(zip(a, b, c, [0, 0, 0]))  # type: ignore
+    y = dask.core.flatten(list(map(list, y)))  # type: ignore
+    y = map(lambda x: x * n, y)  # type: ignore
+    y = ak.from_iter(y)  # type: ignore
 
     assert_eq(x, y)
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -47,3 +47,14 @@ def test_zip(daa, caa) -> None:
     da_z = dak.zip({"a": da1, "b": da2})
     ca_z = ak.zip({"a": ca1, "b": ca2})
     assert_eq(da_z, ca_z)
+
+
+def test_cartesian(daa, caa) -> None:
+    da1 = daa["points", "x"]
+    da2 = daa["points", "y"]
+    ca1 = caa["points", "x"]
+    ca2 = caa["points", "y"]
+
+    dz = dak.cartesian([da1, da2], axis=1)
+    cz = ak.cartesian([ca1, ca2], axis=1)
+    assert_eq(dz, cz)


### PR DESCRIPTION
- Little helpers in `testutils`
- Adding `axis=1` top level `ak.*` namespace functions for:
  - `cartesian`
  - `firsts`
- Other `ak.` namespace functions:
  - `with_name`
  - `ones_like`
  - `zeros_like`
- Scalar repr fix
- some typing improvements
- docstring improvements