### PR TITLE
to_dask_array support for ndim > 1; refactor meta determination.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,13 +44,3 @@ repos:
   rev: v0.3.1
   hooks:
   - id: absolufy-imports
-
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.961
-  hooks:
-  - id: mypy
-    additional_dependencies:
-    - types-PyYAML
-    - numpy
-    - dask
-    - pytest

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -20,7 +20,6 @@ from dask.blockwise import BlockwiseDep
 from dask.blockwise import blockwise as dask_blockwise
 from dask.context import globalmethod
 from dask.highlevelgraph import HighLevelGraph
-from dask.optimization import cull as dask_cull
 from dask.threaded import get as threaded_get
 from dask.utils import IndexCallable, funcname, key_split
 from numpy.lib.mixins import NDArrayOperatorsMixin
@@ -425,7 +424,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             return meta
         if dask.config.get("awkward.compute-unknown-meta"):
             key = (name, 0)
-            new_graph, _ = dask_cull(dsk, key)
+            new_graph = dsk.cull({key})
             return typetracer_array(dask.get(new_graph, key))
         return empty_typetracer()
 

--- a/src/dask_awkward/core.py
+++ b/src/dask_awkward/core.py
@@ -420,6 +420,8 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         name: str,
     ) -> ak.Array:
         if meta is not None:
+            if not isinstance(meta, ak.Array):
+                raise TypeError("meta must be an instance of an Awkward Array.")
             return meta
         if dask.config.get("awkward.compute-unknown-meta"):
             key = (name, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def caa_p2(ndjson_points2: str) -> ak.Array:
 
 
 @pytest.fixture(scope="session")
-def L1() -> list:
+def L1() -> list[list[dict[str, float]]]:
     return [
         [{"x": 1.0, "y": 1.1}, {"x": 2.0, "y": 2.2}, {"x": 3, "y": 3.3}],
         [],
@@ -95,7 +95,7 @@ def L1() -> list:
 
 
 @pytest.fixture(scope="session")
-def L2() -> list:
+def L2() -> list[list[dict[str, float]]]:
     return [
         [{"x": 0.9, "y": 1.0}, {"x": 2.0, "y": 2.2}, {"x": 2.9, "y": 3.0}],
         [],
@@ -106,7 +106,7 @@ def L2() -> list:
 
 
 @pytest.fixture(scope="session")
-def L3() -> list:
+def L3() -> list[list[dict[str, float]]]:
     return [
         [{"x": 1.9, "y": 9.0}, {"x": 2.0, "y": 8.2}, {"x": 9.9, "y": 9.0}],
         [],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,8 +96,6 @@ def test_meta_raise(ndjson_points_file: str) -> None:
 def test_ndim(ndjson_points_file: str) -> None:
     daa = dak.from_json([ndjson_points_file] * 2)
     assert daa.ndim == daa.compute().ndim
-    daa._meta = None
-    assert daa.ndim is None
 
 
 def test_new_array_object_raises(ndjson_points_file: str) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -205,10 +205,10 @@ def test_from_map_exceptions() -> None:
         dak.from_map(f, [1, 2], [3, 4, 5])
 
     with pytest.raises(ValueError, match="must be `callable`"):
-        dak.from_map(5, [1], [2])
+        dak.from_map(5, [1], [2])  # type: ignore
 
     with pytest.raises(ValueError, match="must be Iterable"):
-        dak.from_map(f, 1, [1, 2])
+        dak.from_map(f, 1, [1, 2])  # type: ignore
 
     with pytest.raises(ValueError, match="non-zero length"):
         dak.from_map(f, [], [], [])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -119,15 +119,15 @@ def test_from_dask_array() -> None:
 
 @pytest.mark.parametrize("optimize_graph", [True, False])
 def test_to_and_from_delayed(daa: dak.Array, optimize_graph: bool) -> None:
-    daa = daa[dak.num(daa.points.x, axis=1) > 2]  # type: ignore
-    delayeds = daa.to_delayed(optimize_graph=optimize_graph)
+    daa1 = daa[dak.num(daa.points.x, axis=1) > 2]
+    delayeds = daa1.to_delayed(optimize_graph=optimize_graph)
     daa2 = dak.from_delayed(delayeds)
-    assert_eq(daa, daa2)
-    for i in range(daa.npartitions):
-        assert_eq(daa.partitions[i], delayeds[i].compute())
+    assert_eq(daa1, daa2)
+    for i in range(daa1.npartitions):
+        assert_eq(daa1.partitions[i], delayeds[i].compute())
 
     daa2 = dak.from_delayed(delayeds, divisions=daa.divisions)
-    assert_eq(daa, daa2)
+    assert_eq(daa1, daa2)
 
     with pytest.raises(ValueError, match="divisions must be a tuple of length"):
         dak.from_delayed(delayeds, divisions=(1, 5, 7, 9, 11))
@@ -205,10 +205,10 @@ def test_from_map_exceptions() -> None:
         dak.from_map(f, [1, 2], [3, 4, 5])
 
     with pytest.raises(ValueError, match="must be `callable`"):
-        dak.from_map(5, [1], [2])  # type: ignore
+        dak.from_map(5, [1], [2])
 
     with pytest.raises(ValueError, match="must be Iterable"):
-        dak.from_map(f, 1, [1, 2])  # type: ignore
+        dak.from_map(f, 1, [1, 2])
 
     with pytest.raises(ValueError, match="non-zero length"):
         dak.from_map(f, [], [], [])
@@ -242,6 +242,13 @@ def test_to_dask_array(daa: dak.Array, caa: dak.Array) -> None:
     da_assert_eq(da, ca)
     da = dak.flatten(daa.points.x).to_dask_array()
     da_assert_eq(da, ca)
+
+
+def test_to_dask_array_multidim() -> None:
+    c = ak.Array([[[1, 2, 3]], [[4, 5, 6]]])
+    a = dak.from_awkward(c, npartitions=2)
+    d = dak.to_dask_array(a)
+    da_assert_eq(d, ak.to_numpy(c))
 
 
 @pytest.mark.parametrize("optimize_graph", [True, False])


### PR DESCRIPTION
- Add support for `to_dask_array` where the awkward array collection is known to be multidimensional.
- Refactor the computation of metadata in cases where it's unknown