### PR TITLE
docs: use sphinx-design to compare Awkward

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.todo",
+    "sphinx_design",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -37,7 +37,7 @@ with the same programming style; on the left we operate eagerly with
     .. grid-item-card::  Awkward Array
 
         .. code-block:: python
-        
+
            import awkward._v2 as ak
            x = ak.from_json("data.00.json")
            x = x[ak.num(x.foo) > 2]

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -32,11 +32,26 @@ with the same programming style; on the left we operate eagerly with
 ``awkward`` and on the right we operate lazily with ``dask-awkward``
 (notice the ``compute()`` method call):
 
-.. code-block:: python
+.. grid:: 2
 
-   import awkward._v2 as ak                import dask_awkward as dak
-   x = ak.from_json("data.00.json")        x = dak.from_json("data.*.json")
-   x = x[ak.num(x.foo) > 2]                x = x[dak.num(x.foo).compute()
+    .. grid-item-card::  Awkward Array
+
+        .. code-block:: python
+        
+           import awkward._v2 as ak
+           x = ak.from_json("data.00.json")
+           x = x[ak.num(x.foo) > 2]
+
+    .. grid-item-card::  Dask
+
+        .. code-block:: python
+
+           import dask_awkward as dak
+           x = dak.from_json("data.*.json")
+           x = x[dak.num(x.foo) > 2]
+
+           # Compute result
+           x = x.compute()
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ complete = [
 docs = [
     "dask-sphinx-theme >=3.0.2",
     "pyarrow",
+    "sphinx-design",
     "pytest >=6.0",
     "pytest-cov >=3.0.0",
     "requests >=2.27.1",


### PR DESCRIPTION
This tiny PR does two things:

1. Correct the demo code @douglasdavis can you check that my "fix" is correct for the `intro.rst` Dask example?
2. Adds sphinx-design and uses panels to compare awkward with dask-awkward:

![image](https://user-images.githubusercontent.com/1248413/190657552-c7433068-1c58-4758-883a-17ddbe3da664.png)
