### PR TITLE
Guard against pyarrow import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     language_version: python3
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.37.3
+  rev: v2.38.0
   hooks:
   - id: pyupgrade
     args:

--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -4,7 +4,6 @@ import math
 import operator
 
 import fsspec
-import pyarrow.parquet as pq
 from awkward._v2.operations import ak_from_parquet, from_buffers, to_arrow_table
 from awkward._v2.operations.ak_from_parquet import _load
 from dask.base import tokenize
@@ -186,6 +185,8 @@ def _metadata_file_from_data_files(path_list, fs, out_path):
     out_path: str
         Root directory of the dataset
     """
+    import pyarrow.parquet as pq
+
     meta = None
     out_path = out_path.rstrip("/")
     for path in path_list:
@@ -229,6 +230,8 @@ def _write_partition(
     head=False,  # is this the first piece
     # custom_metadata=None,
 ):
+    import pyarrow.parquet as pq
+
     t = to_arrow_table(
         data,
         list_to32=True,


### PR DESCRIPTION
@martindurant what do you think? This was mentioned here: https://github.com/scikit-hep/uproot5/pull/714#issuecomment-1250099755

If another part of `dask_awkward.lib` (e.g. `dask_awkward.lib.testutils`) is imported then `dask_awkward.lib.io.parquet` gets imported. Can you think of another module-organization method to avoid this other than adding the pyarrow import to the function bodies where necessary?