### PR TITLE
Total reduction with high level layer(s)

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import keyword
 import operator
+import sys
 import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from functools import cached_property, partial
@@ -1179,6 +1180,7 @@ def map_partitions(
     fn: Callable,
     *args: Any,
     label: str | None = None,
+    token: str | None = None,
     meta: Any | None = None,
     output_divisions: int | None = None,
     **kwargs: Any,
@@ -1197,6 +1199,9 @@ def map_partitions(
     label : str, optional
         Label for the Dask graph layer; if left to ``None`` (default),
         the name of the function will be used.
+    token : str, optional
+        Provide an already defined token. If ``None`` a new token will
+        be generated.
     meta : Any, optional
         Metadata (typetracer) array for the result (if known). If
         unknown, `fn` will be applied to the metadata of the `args`;
@@ -1248,7 +1253,7 @@ def map_partitions(
     This is effectively the same as `d = c * a`
 
     """
-    token = tokenize(fn, *args, **kwargs)
+    token = token or tokenize(fn, *args, meta, **kwargs)
     label = label or funcname(fn)
     name = f"{label}-{token}"
     lay = partitionwise_layer(fn, name, *args, **kwargs)
@@ -1296,147 +1301,55 @@ def map_partitions(
         )
 
 
-# def total_reduction(
-#     func: Callable,
-#     array: Array,
-#     split_every: int | None = None,
-#     label: str | None = None,
-#     meta: Any | None = None,
-# ) -> Scalar:
-#     from dask.bag.core import empty_safe_aggregate, empty_safe_apply
-#     from tlz import partition_all
+def _total_reduction_to_scalar(
+    array: Array,
+    fn: Callable,
+    *,
+    label: str | None = None,
+    token: str | None = None,
+    dtype: Any | None = None,
+    meta: Any | None = None,
+    split_every: int | bool | None = None,
+    **kwargs: Any,
+) -> Any:
+    from dask.layers import DataFrameTreeReduction
 
-#     splitev: int = split_every or 8
-#     npartitions = array.npartitions
-#     is_last = npartitions == 1
+    meta = meta or fn(array._meta, **kwargs)
+    label = label or funcname(fn)
+    token = token or tokenize(array, fn, label, dtype, kwargs)
+    name_comb = f"{label}-combine-{token}"
+    name_agg = f"{label}-agg-{token}"
 
-#     token = tokenize(func, array, splitev)
-#     label = label or funcname(func)
+    fn = partial(fn, **kwargs)
 
-#     a_name = f"{label}-part-{token}"
+    chunked_result = map_partitions(
+        fn,
+        array,
+        meta=empty_typetracer(),
+    )
 
-#     dsk: dict[Any, Any] = {
-#         (a_name, i): (empty_safe_apply, func, (array.name, i), is_last)
-#         for i in range(npartitions)
-#     }
+    if split_every is None:
+        split_every = 8
+    elif split_every is False:
+        split_every = sys.maxsize
+    else:
+        pass
 
-#     b_name = a_name
-#     k = npartitions
-#     fmt_name = f"{label}-aggregate-{token}"
-#     depth = 0
+    dftr = DataFrameTreeReduction(
+        name=name_agg,
+        name_input=chunked_result.name,
+        npartitions_input=chunked_result.npartitions,
+        concat_func=ak.from_iter,
+        tree_node_func=fn,
+        finalize_func=fn,
+        split_every=split_every,
+        tree_node_name=name_comb,
+    )
 
-#     while k > splitev:
-#         c_name = f"{fmt_name}{depth}"
-#         i = 0
-#         for indices in partition_all(splitev, range(k)):
-#             dsk[(c_name, i)] = (
-#                 empty_safe_aggregate,
-#                 func,
-#                 [(b_name, j) for j in indices],
-#                 False,
-#             )
-#             i += 1
-#         k = i + 1
-#         b_name = c_name
-#         depth += 1
-
-#     dsk[(fmt_name, 0)] = (
-#         empty_safe_aggregate,
-#         func,
-#         [(b_name, j) for j in range(k)],
-#         True,
-#     )
-#     # dsk[fmt_name] = dsk.pop((fmt_name, 0))
-
-#     graph = HighLevelGraph.from_collections(fmt_name, dsk, dependencies=[array])
-#     return new_scalar_object(graph, fmt_name, meta=meta or UnknownScalar(None))
-
-
-# def _max_or_ident(a):
-#     if isinstance(a, (list, tuple)):
-#         print("list/tuple:", a)
-#         ak.max(ak.Array(a), axis=None)
-#     elif isinstance(a, ak.Array):
-#         print("ak.Array", a)
-#         return a
-#     else:
-#         print("idk:", type(a), a)
-#         return a
-
-
-# def _reduction_partition(x: Any, fn: Callable, **kwargs: Any) -> Any:
-#     output = fn(x, **kwargs)
-#     return output
-
-
-# def _reduction_combine(x: Any, fn: Callable, **kwargs: Any) -> Any:
-#     if isinstance(x, list):
-#         x = ak.Array(x)
-#     output = fn(x, **kwargs)
-#     return output
-
-
-# def _reduction_aggregate(x: Any, fn: Callable, **kwargs: Any) -> Any:
-#     if isinstance(x, list):
-#         x = ak.Array(x)
-#     output = fn(x, **kwargs)
-#     return output
-
-
-# def reduction_to_scalar(
-#     array: Array,
-#     fn_per_partition: Callable,
-#     fn_combine: Callable | None = None,
-#     fn_aggregate: Callable | None = None,
-#     split_every: int | None = 8,
-#     per_partition_kwargs: dict[str, Any] | None = None,
-#     combine_kwargs: dict[str, Any] | None = None,
-#     aggregate_kwargs: dict[str, Any] | None = None,
-#     meta: Any | None = None,
-#     label: str | None = None,
-#     token: str | None = None,
-# ) -> Scalar:
-
-#     if fn_aggregate is None:
-#         fn_aggregate = fn_per_partition
-
-#     if fn_combine is None:
-#         fn_combine = fn_aggregate
-
-#     per_partition_kwargs = per_partition_kwargs.copy() if per_partition_kwargs else {}
-#     per_partition_kwargs["fn"] = fn_per_partition
-
-#     combine_kwargs = combine_kwargs.copy() if combine_kwargs else {}
-#     combine_kwargs["fn"] = fn_combine
-
-#     aggregate_kwargs = aggregate_kwargs.copy() if aggregate_kwargs else {}
-#     aggregate_kwargs["fn"] = fn_aggregate
-
-#     token = tokenize(
-#         token or (fn_per_partition, fn_aggregate),
-#     )
-
-#     chunked_result = map_partitions(fn_per_partition, array, meta=empty_typetracer())
-
-#     from dask.layers import DataFrameTreeReduction
-
-#     if split_every is None:
-#         split_every = 8
-
-#     label = label or funcname(fn_per_partition)
-
-#     dftr = DataFrameTreeReduction(
-#         name,
-#         chunked_result.name,
-#         chunked_result.npartitions,
-#         fnagg,
-#         _max_or_ident,
-#         split_every=split_every,
-#         tree_node_name=f"reduce-{token}",
-#     )
-
-#     graph = HighLevelGraph.from_collections(name, dftr, dependencies=(chunked_result,))
-#     return new_scalar_object(graph, name, meta=meta or UnknownScalar(None))
+    graph = HighLevelGraph.from_collections(
+        name_agg, dftr, dependencies=(chunked_result,)
+    )
+    return new_scalar_object(graph, name_agg, meta=meta)
 
 
 def pw_reduction_with_agg_to_scalar(

--- a/src/dask_awkward/lib/reducers.py
+++ b/src/dask_awkward/lib/reducers.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING, Any
 import awkward as ak
 import numpy as np
 
-from dask_awkward.lib.core import map_partitions, pw_reduction_with_agg_to_scalar
+from dask_awkward.lib.core import (
+    _total_reduction_to_scalar,
+    map_partitions,
+    pw_reduction_with_agg_to_scalar,
+)
 from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
 
 if TYPE_CHECKING:
@@ -264,13 +268,12 @@ def max(
             flatten_records=flatten_records,
         )
     if axis is None:
-        return pw_reduction_with_agg_to_scalar(
-            ak.max,
-            ak.max,
+        return _total_reduction_to_scalar(
             array,
+            ak.max,
             axis=None,
+            mask_identity=mask_identity,
             flatten_records=flatten_records,
-            agg_kwargs={"axis": None, "flatten_records": flatten_records},
         )
     else:
         raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
@@ -327,12 +330,12 @@ def min(
             flatten_records=flatten_records,
         )
     if axis is None:
-        return pw_reduction_with_agg_to_scalar(
-            ak.min,
-            ak.min,
+        return _total_reduction_to_scalar(
             array,
+            ak.min,
             axis=None,
-            agg_kwargs={"axis": None},
+            mask_identity=mask_identity,
+            flatten_records=flatten_records,
         )
     else:
         raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
@@ -402,7 +405,13 @@ def sum(
             flatten_records=flatten_records,
         )
     elif axis is None:
-        return pw_reduction_with_agg_to_scalar(ak.sum, ak.sum, array)
+        return _total_reduction_to_scalar(
+            array,
+            ak.sum,
+            axis=None,
+            flatten_records=flatten_records,
+            mask_identity=mask_identity,
+        )
     elif axis == 0:
         raise DaskAwkwardNotImplemented(
             f"axis={axis} is not supported for this array yet."

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -6,12 +6,13 @@ from typing import TYPE_CHECKING, Any
 
 import awkward as ak
 import numpy as np
+from awkward._typetracer import UnknownScalar
 
 from dask_awkward.lib.core import (
     Array,
+    _total_reduction_to_scalar,
     map_partitions,
     new_known_scalar,
-    pw_reduction_with_agg_to_scalar,
 )
 from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
 
@@ -322,15 +323,14 @@ def num(
         if array.known_divisions:
             return new_known_scalar(array.divisions[-1], dtype=int)
         else:
-            return pw_reduction_with_agg_to_scalar(
-                func=ak.num,
-                agg=ak.sum,
+            return _total_reduction_to_scalar(
+                label="num",
                 array=array,
-                axis=0,
-                dtype=np.int64,
-                agg_kwargs={"axis": None},
-                highlevel=highlevel,
-                behavior=behavior,
+                meta=UnknownScalar(np.dtype(int)),
+                chunked_fn=ak.num,
+                chunked_kwargs={"axis": 0},
+                comb_fn=ak.sum,
+                comb_kwargs={"axis": None},
             )
     raise DaskAwkwardNotImplemented("TODO")
 


### PR DESCRIPTION
Replaces `pw_reduction_with_agg_to_scalar` (partitionwise reduction with aggregate to scalar) with `_total_reduction_to_scalar`. The former uses a low level graph for the reduction step. The later is now all high level graphs. This isn't quite as flexible as the upstream dask `apply_concat_apply` strategy, but it's a good step in that direction. This code will certainly evolve over time as needed.