### PR TITLE
parquet fixes

### DIFF
--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -158,7 +158,7 @@ def from_parquet(
                 ]  # returns 1st if fp is empty
                 rgs_paths[rgs_path] += 1
 
-            subrg = [list(range(i)) for _ in actual_paths]
+            subrg = [list(range(i + 1)) for _ in actual_paths]
 
         rgs = [metadata.row_group(i) for i in range(metadata.num_row_groups)]
         divisions = [0] + list(

--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -145,3 +145,33 @@ def list3() -> list:
 
 def lists() -> Array:
     return from_lists([list1(), list2(), list3()])  # pragma: no cover
+
+
+def unnamed_root_ds() -> Array:
+    ds = [
+        [
+            {
+                "minutes": 33,
+                "passes": {"to": [2, 5, 6], "success": [True, True, False]},
+            },
+            {
+                "minutes": 34,
+                "passes": {"to": [5, 6, 7, 8], "success": [False, False, True, True]},
+            },
+        ],
+        [
+            {
+                "minutes": 24,
+                "passes": {"to": [0, 3, 4, 5], "success": [True, True, True, False]},
+            },
+            {
+                "minutes": 3,
+                "passes": {"to": [], "success": []},
+            },
+            {
+                "minutes": 18,
+                "passes": {"to": [0, 3, 4, 5], "success": [False, True, True, False]},
+            },
+        ],
+    ]
+    return ak.Array(ds * 3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,3 +121,12 @@ def caa_parquet(caa: ak.Array, tmpdir_factory: pytest.TempdirFactory) -> str:
     fname = tmpdir_factory.mktemp("parquet_data") / "caa.parquet"  # type: ignore
     ak.to_parquet(caa, str(fname), extensionarray=False)
     return str(fname)
+
+
+@pytest.fixture(scope="session")
+def unnamed_root_parquet_file(tmpdir_factory: pytest.TempdirFactory) -> str:
+    from dask_awkward.lib.testutils import unnamed_root_ds
+
+    fname = tmpdir_factory.mktemp("unnamed_parquet_data") / "file.parquet"
+    ak.to_parquet(unnamed_root_ds(), str(fname), extensionarray=False, row_group_size=3)
+    return str(fname)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -41,9 +41,19 @@ def test_remote_single(ignore_metadata, scan_files):
 
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
-def test_remote_double(ignore_metadata, scan_files):
+@pytest.mark.parametrize(
+    "split_row_groups",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.xfail(reason="same file used twice")),
+    ],
+)
+def test_remote_double(ignore_metadata, scan_files, split_row_groups):
     arr = dak.from_parquet(
-        [sample, sample], ignore_metadata=ignore_metadata, scan_files=scan_files
+        [sample, sample],
+        ignore_metadata=ignore_metadata,
+        scan_files=scan_files,
+        split_row_groups=split_row_groups,
     )
     assert arr.npartitions == 2
     assert (

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 pytest.importorskip("pyarrow")


### PR DESCRIPTION
this PR fixes `from_parquet` in two areas:

1. the case where the we have an "unnamed root" in a column (e.g. `.list.item.column.list.item`)
2. the case where splitting by row groups created a task graph that was one element too small