### PR TITLE
to_parquet: mkdirs

### DIFF
--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -321,8 +321,7 @@ class _ToParquetFn:
             math.ceil(math.log(npartitions, 10)) if npartitions is not None else 1
         )
 
-        if self.fs.protocol == "file":
-            self.fs.mkdir(self.path)
+        self.fs.mkdirs(self.path, exist_ok=True)
 
     def __call__(self, data, block_index):
         filename = f"part{str(block_index[0]).zfill(self.zfill)}.parquet"

--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -321,6 +321,9 @@ class _ToParquetFn:
             math.ceil(math.log(npartitions, 10)) if npartitions is not None else 1
         )
 
+        if self.fs.protocol == "file":
+            self.fs.mkdir(self.path)
+
     def __call__(self, data, block_index):
         filename = f"part{str(block_index[0]).zfill(self.zfill)}.parquet"
         return _write_partition(


### PR DESCRIPTION
@martindurant does this make sense? (without this `dak.to_parquet(array, "some_dir")` crashes if `some_dir` doesn't exist)